### PR TITLE
Move segmentMap_ outside of Event class, remove ETASEG ifdef

### DIFF
--- a/Event.h
+++ b/Event.h
@@ -16,9 +16,9 @@ public:
   void Reset(int evtID);
   void RemapHits(TrackVec & tracks);
   void Simulate();
-  void Segment();
-  void Seed();
-  void Find();
+  void Segment(BinInfoMap & segmentMap);
+  void Seed(const BinInfoMap & segmentMap);
+  void Find(const BinInfoMap & segmentMap);
   void Fit();
   void Validate();
   void PrintStats(const TrackVec&, TrackExtraVec&);
@@ -51,10 +51,6 @@ public:
   // XXXXMT: Preliminary ... separators into seed/candidate arrays.
   // There should be a better way of doing that.
   int seedEtaSeparators_[5];
-
-  // phi-eta partitioning map: vector of vector of vectors of std::pairs. 
-  // vec[nLayers][nEtaBins][nPhiBins]
-  BinInfoMap segmentMap_;
 
   TSVec simTrackStates_;
   static std::mutex printmutex;

--- a/Makefile.config
+++ b/Makefile.config
@@ -109,10 +109,7 @@ ENDTOEND := -DENDTOEND
 # have to be adjusted.
 WITH_TBB := yes
 
-# 14. Use for eta-phi segmentation
-USE_ETA_SEGMENTATION := -DETASEG
-
-# 15. Use inward fit in Conformal fit + final KF Fit
+# 14. Use inward fit in Conformal fit + final KF Fit
 INWARD_FIT := -DINWARDFIT
 
 ################################################################
@@ -137,7 +134,7 @@ ifdef USE_CUDA
 	endif
 endif
 
-CPPFLAGS += ${USE_STATE_VALIDITY_CHECKS} ${USE_SCATTERING} ${USE_LINEAR_INTERPOLATION} ${ENDTOEND} ${USE_ETA_SEGMENTATION} ${INWARD_FIT} ${GEN_FLAT_ETA}
+CPPFLAGS += ${USE_STATE_VALIDITY_CHECKS} ${USE_SCATTERING} ${USE_LINEAR_INTERPOLATION} ${ENDTOEND} ${INWARD_FIT} 
 
 ifdef USE_VTUNE_NOTIFY
   ifdef VTUNE_AMPLIFIER_XE_2016_DIR

--- a/buildtest.h
+++ b/buildtest.h
@@ -8,7 +8,8 @@
 #include "Track.h"
 #include "Geometry.h"
 #include "Event.h"
+#include "BinInfoUtils.h"
 
-void buildTracksBySeeds(Event& ev);
-void buildTracksByLayers(Event& ev);
+void buildTracksBySeeds(const BinInfoMap &, Event& ev);
+void buildTracksByLayers(const BinInfoMap &, Event& ev);
 #endif

--- a/main.cc
+++ b/main.cc
@@ -11,6 +11,7 @@
 #include "Matrix.h"
 #include "Event.h"
 #include "Validation.h"
+#include "BinInfoUtils.h"
 
 #include "fittestEndcap.h"
 
@@ -285,12 +286,16 @@ int main(int argc, const char* argv[])
       continue;
     }
 
- /*simulate time*/ ticks[0] += delta(t0);
-    ev.Segment();  ticks[1] += delta(t0);
-    ev.Seed();     ticks[2] += delta(t0);
-    ev.Find();     ticks[3] += delta(t0);
-    ev.Fit();      ticks[4] += delta(t0);
-    ev.Validate(); ticks[5] += delta(t0);
+    // phi-eta partitioning map: vector of vector of vectors of std::pairs. 
+    // vec[nLayers][nEtaBins][nPhiBins]
+    BinInfoMap segmentMap;
+
+    /*simulate time*/        ticks[0] += delta(t0);
+    ev.Segment(segmentMap);  ticks[1] += delta(t0);
+    ev.Seed(segmentMap);     ticks[2] += delta(t0);
+    ev.Find(segmentMap);     ticks[3] += delta(t0);
+    ev.Fit();                ticks[4] += delta(t0);
+    ev.Validate();           ticks[5] += delta(t0);
 
     std::cout << "sim: " << ev.simTracks_.size() << " seed: " << ev.seedTracks_.size() << " found: " 
 	      << ev.candidateTracks_.size() << " fit: " << ev.fitTracks_.size() << std::endl;

--- a/seedtest.cc
+++ b/seedtest.cc
@@ -314,13 +314,8 @@ void buildHitPairs(const std::vector<HitVec>& evt_lay_hits, const BinInfoLayerMa
     const float outerhitz = evt_lay_hits[1][ihit].z(); // remember, layer[0] is first layer! --> second layer = [1]
     const float outerphi  = evt_lay_hits[1][ihit].phi();
 
-#ifdef ETASEG   // z cut is the largest killer... up to 3 sigma is probably best
     const auto etaBinMinus = getEtaPartition(getEta(Config::fRadialSpacing,(outerhitz-Config::seed_z0cut)/2.));
     const auto etaBinPlus  = getEtaPartition(getEta(Config::fRadialSpacing,(outerhitz+Config::seed_z0cut)/2.));
-#else
-    const auto etaBinMinus = 0;
-    const auto etaBinPlus  = 0;
-#endif
     const auto phiBinMinus = getPhiPartition(normalizedPhi(outerphi - Config::lay01angdiff));
     const auto phiBinPlus  = getPhiPartition(normalizedPhi(outerphi + Config::lay01angdiff));
 
@@ -382,23 +377,11 @@ void buildHitTripletsCurve(const std::vector<HitVec>& evt_lay_hits, const BinInf
     intersectThirdLayer(aneg,bneg,x1,y1,negx2,negy2);
     const float negPhi = getPhi(negx2,negy2);
 
-#ifdef ETASEG
     const float thirdZline = 2*hit1.z()-hit0.z(); // for dz displacements -- straight line window
     const auto etaBinMinus = getEtaPartition(getEta(lay3rad,thirdZline)-Config::dEtaSeedTrip);
     const auto etaBinPlus  = getEtaPartition(getEta(lay3rad,thirdZline)+Config::dEtaSeedTrip);
-#else
-    const auto etaBinMinus = 0;
-    const auto etaBinPlus  = 0;
-#endif    
     const auto phiBinMinus = getPhiPartition(negPhi);
     const auto phiBinPlus  = getPhiPartition(posPhi);
-
-#ifdef BROKEN_DEBUG
-    const float lay2phi = evt_lay_hits[2][ev.simTracks_[ev.simHitsInfo_[hit0.mcHitID()].mcTrackID()].getHitIdx(2)].phi();
-    dprint("lay0 phi: " << hit0.phi() << " lay1 phi: " << hit1.phi() << std::endl <<
-	   "negPhi: " << negPhi << " lay2 phi: " << lay2phi << " posPhi: " << posPhi << std::endl <<
-	   "binM: " << phiBinMinus << " phi2Bin: " << getPhiPartition(lay2phi) << " binP: " << phiBinPlus << std::endl);
-#endif
 
     std::vector<int> cand_hit_indices = getCandHitIndices(etaBinMinus,etaBinPlus,phiBinMinus,phiBinPlus,segLayMap);
     for (auto&& cand_hit_idx : cand_hit_indices){
@@ -439,14 +422,10 @@ void buildHitTripletsApproxWindow(const std::vector<HitVec>& evt_lay_hits, const
     const Hit& hit0 = evt_lay_hits[0][hit_pair[0]];
     const Hit& hit1 = evt_lay_hits[1][hit_pair[1]];
 
-#ifdef ETASEG
     const float thirdZline = 2*hit1.z()-hit0.z(); // for dz displacements -- straight line window
     const auto etaBinMinus = getEtaPartition(getEta(thirdRad,thirdZline)-Config::dEtaSeedTrip);
     const auto etaBinPlus  = getEtaPartition(getEta(thirdRad,thirdZline)+Config::dEtaSeedTrip);
-#else
-    const auto etaBinMinus = 0;
-    const auto etaBinPlus  = 0;
-#endif    
+
     const float linePhi = getPhi(hit1.position()[0] - hit0.position()[0], hit1.position()[1] - hit0.position()[1]);
     float thirdPhiMinus = 0.0f;
     float thirdPhiPlus  = 0.0f;  


### PR DESCRIPTION
I moved segmentMap_ outside of the Event class to be passed around to the various SMatrix building routines (Segment(), Seed(), and Find()). 

In addition, I removed the ifdef on ETASEG inside the SMatrix routines, because we have always used eta-phi segmentation in the SMatrix routines.  One less ifdef now.