### PR TITLE
split SelectHitIndices loop into vectorizable and non-vector loops

### DIFF
--- a/Event.cc
+++ b/Event.cc
@@ -14,6 +14,8 @@
 #include "tbb/tbb.h"
 #endif
 
+#include <memory>
+
 std::mutex Event::printmutex;
 
 inline bool sortByPhi(const Hit& hit1, const Hit& hit2)


### PR DESCRIPTION
Minimal change to split the SelectHitIndices loop into a piece that vectorizes and a second that doesn't by introducing temporary arrays (what the compiler would have done if the loop vectorized).

Also fix one mysteriously missing header for Event.cc.