### PR TITLE
QUICK: bug fix for counting of unique layers

### DIFF
--- a/Track.h
+++ b/Track.h
@@ -312,10 +312,10 @@ public:
   {
     int lyr_cnt  =  0;
     int prev_lyr = -1;
-    for (int ihit = 0; ihit < lastHitIdx_ ; ++ihit)
+    for (int ihit = 0; ihit <= lastHitIdx_ ; ++ihit)
     {
       int h_lyr = hitsOnTrk_[ihit].layer;
-      if (h_lyr >= 0 && h_lyr != prev_lyr)
+      if (h_lyr >= 0 && hitsOnTrk_[ihit].index >= 0 && h_lyr != prev_lyr)
       {
         ++lyr_cnt;
         prev_lyr = h_lyr;


### PR DESCRIPTION
lastHitIdx_ starting at -1 strikes again.  

noticed that when computing the number of unique layers by hand, the method inside the track class was off by -1 (or lower).  

this will boost the number of eligible sim seeds ever so slightly.  to restore the original amount of sim   seeds, we need to bump Config::cmsSimSelMinLayers to 9 (from 8).

EDIT:
I also noticed that in some cases nUniqueLayers > nFoundHits...  which should never be the case.  In fact, these two ought to be equal for all built mkFit tracks (as we only add one hit per layer at most -- no overlaps).  And for simTracks (toyMC or CMSSW) it should be nUniqueLayers <= nFoundHits. 

This was because even though a hit was not found (i.e. hitsOnTrk_[ihit].index == -1), the hitsOnTrk_[ihit] was equal to whatever layer the track was exploring.  As such, the check on lyr >=0 is not sufficient.  