### PR TITLE
Fixes to non-root based validation

### DIFF
--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -853,7 +853,7 @@ void MkBuilder::quality_process(Track &tkcand)
 {
   TrackExtra extra(tkcand.label());
   
-  if (Config::useCMSGeom || Config::findSeeds)
+  if (Config::readCmsswSeeds || Config::findSeeds)
   {
     extra.setMCTrackIDInfo(tkcand, m_event->layerHits_, m_event->simHitsInfo_, m_event->simTracks_, false);
   }
@@ -877,8 +877,8 @@ void MkBuilder::quality_process(Track &tkcand)
   {
     ptmc  = m_event->simTracks_[mctrk].pT() ;
     pr    = pt / ptmc;
-    // XXXXMT4K Requires Track::nFoundUniqueLayerHits() or Track::nFoundLayers()
-    nfoundmc = m_event->simTracks_[mctrk].nFoundHits();
+    m_event->simTracks_[mctrck].sortHitsByLayer();
+    nfoundmc = m_event->simTracks_[mctrk].nUniqueLayers();
     chi2mc = m_event->simTracks_[mctrk].chi2();//this is actually the number of reco hits in cmssw
 
     ++m_cnt;


### PR DESCRIPTION
When not using root for validation, force the track matching to be done based on seed type, not geometry.

i.e. regardless of using the toy or CMS geom, using sim seeds triggers the use of the "by label" matching, while using seeds we or cms generated, the track matching is done via the 75% criterion.