### PR TITLE
Removing vectorization pragma from seed cleaning

### DIFF
--- a/Event.cc
+++ b/Event.cc
@@ -729,6 +729,7 @@ int Event::clean_cms_seedtracks()
     const float Eta1 = eta[ts];
     const float invptq_first = invptq[ts]; 
 
+    //#pragma simd /* Vectorization via simd had issues with icc */
     for (int tss= ts+1; tss<ns; tss++){
 
       if (nHits[tss] < minNHits) continue;


### PR DESCRIPTION
PR aimed at removing issue with loop vectorization in Event.cc, for seed cleaning.
Based on observation of different results obtained when compiling using icc or gcc: after compilation with icc, results do NOT appear to be reliable.

Also tried to replace "#pragma simd" with "#pragma ivdep" or "#pragma vector always".
"simd" is the only pragma that gives unreliable results. Moreover, "simd" may give (slightly) different results wrt. itself from time to time.
As with other pragmas when compiling with icc the concerned loop is anyways not vectorized (see compilation reports below), choice was simply to remove the pragma (line is currently commented out).

Original figure of merit was duplicate rate. Here are results of validation on 10 muon sample for different options (NOTE: dR<0.1 is used for seed cleaning, that is supposed to give ~0 duplicate rate):
a. gcc with simd: https://mmasciov.web.cern.ch/mmasciov/fullval_plots_10mu_dr0p1_gcc/?match=*FullDet_dr_eta_pt0.0*
b. icc with simd: https://mmasciov.web.cern.ch/mmasciov/fullval_plots_10mu_dr0p1_icc_simd/?match=*FullDet_dr_eta_pt0.0* 
c. icc with NO vectorization pragma: https://mmasciov.web.cern.ch/mmasciov/fullval_plots_10mu_dr0p1_icc_nosimd/?match=*FullDet_dr_eta_pt0.0*
d. icc with ivdep: https://mmasciov.web.cern.ch/mmasciov/fullval_plots_10mu_dr0p1_icc_ivdep/?match=*FullDet_dr_eta_pt0.0*
e. icc with vector always: https://mmasciov.web.cern.ch/mmasciov/fullval_plots_10mu_dr0p1_icc_vecalways/?match=*FullDet_dr_eta_pt0.0*

As you can see, option (b) is the only one giving different results, that are different than expectation.

From compilation reports (Event.optrpt):
1) #pragma ivdep
   LOOP BEGIN at Event.cc(734,5)
      remark #15335: loop was not vectorized: vectorization possible but seems inefficient. Use vector always directive or -vec-threshold0 to override 
      remark #25018: Total number of lines prefetched=14
   LOOP END

2) #pragma vector always
   LOOP BEGIN at Event.cc(734,5)
      remark #15344: loop was not vectorized: vector dependence prevents vectorization. First dependence is shown below. Use level 5 report for details
      remark #15346: vector dependence: assumed FLOW dependence between writetrack.__b_St13_Bvector_baseISaIbEE._M_impl._M_start.__b_St1 (88:3) and writetrack.__b_St13_Bvector_baseISaIbEE._M_impl._M_start.__b_St1 (88:3)
      remark #25018: Total number of lines prefetched=14
   LOOP END

3) #pragma simd
   LOOP BEGIN at Event.cc(734,5)
   <Peeled loop for vectorization>
      remark #15335: peel loop was not vectorized: vectorization possible but seems inefficient. Use vector always directive or -vec-threshold0 to override 
   LOOP END

   LOOP BEGIN at Event.cc(734,5)
      remark #15301: SIMD LOOP WAS VECTORIZED
      remark #25018: Total number of lines prefetched=14
   LOOP END

   LOOP BEGIN at Event.cc(734,5)
   <Remainder loop for vectorization>
      remark #15335: remainder loop was not vectorized: vectorization possible but seems inefficient. Use vector always directive or -vec-threshold0 to override 
   LOOP END