### PR TITLE
Updating seed cleaning

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -253,9 +253,24 @@ namespace Config
   extern bool applyCMSSWHitMatch;
 
   // config on seed cleaning
-  constexpr double maxDR_seedclean = 0.005;
   constexpr int minNHits_seedclean = 4;
-  constexpr double track1GeVradius = 87.6; // = 1/(c*B)
+  constexpr float track1GeVradius = 87.6; // = 1/(c*B)
+  constexpr float c_etamax_brl = 0.9;
+  constexpr float c_dpt_brl_0 = 0.025;
+  constexpr float c_dpt_ec_0 = 0.0125;
+  constexpr float c_ptmax_0 = 2.0;
+  constexpr float c_dpt_1 = 0.10;
+  constexpr float c_ptmax_1 = 5.0;
+  constexpr float c_dpt_2 = 0.20;
+  constexpr float c_ptmax_2 = 10.0;
+  constexpr float c_dpt_3 = 0.25;
+  constexpr float c_dzmax_brl = 0.005;
+  constexpr float c_drmax_brl = 0.010;
+  constexpr float c_ptmin_hpt = 2.0;
+  constexpr float c_dzmax_hpt = 0.010;
+  constexpr float c_drmax_hpt = 0.010;
+  constexpr float c_dzmax_els = 0.015;
+  constexpr float c_drmax_els = 0.015;
 
   // Threading
   extern int    numThreadsFinder;

--- a/Event.cc
+++ b/Event.cc
@@ -690,8 +690,30 @@ void Event::print_tracks(const TrackVec& tracks, bool print_hits) const
 int Event::clean_cms_seedtracks()
 {
 
-  double maxDR2 = Config::maxDR_seedclean*Config::maxDR_seedclean;
-  int minNHits = Config::minNHits_seedclean;
+  int minNHits     = Config::minNHits_seedclean;
+  float etamax_brl = Config::c_etamax_brl;
+  float dpt_brl_0  = Config::c_dpt_brl_0;
+  float dpt_ec_0   = Config::c_dpt_ec_0;
+  float ptmax_0    = Config::c_ptmax_0;
+  float dpt_1      = Config::c_dpt_1;
+  float ptmax_1    = Config::c_ptmax_1;
+  float dpt_2      = Config::c_dpt_2;
+  float ptmax_2    = Config::c_ptmax_2;
+  float dpt_3      = Config::c_dpt_3;
+  float dzmax_brl  = Config::c_dzmax_brl;
+  float drmax_brl  = Config::c_drmax_brl;
+  float ptmin_hpt  = Config::c_ptmin_hpt;
+  float dzmax_hpt  = Config::c_dzmax_hpt;
+  float drmax_hpt  = Config::c_drmax_hpt;
+  float dzmax_els  = Config::c_dzmax_els;
+  float drmax_els  = Config::c_drmax_els;
+
+  float dzmax2_brl = dzmax_brl*dzmax_brl;
+  float drmax2_brl = drmax_brl*drmax_brl;
+  float dzmax2_hpt = dzmax_hpt*dzmax_hpt;
+  float drmax2_hpt = drmax_hpt*drmax_hpt;
+  float dzmax2_els = dzmax_els*dzmax_els;
+  float drmax2_els = drmax_els*drmax_els;
 
   int ns = seedTracks_.size();
 
@@ -746,7 +768,7 @@ int Event::clean_cms_seedtracks()
 
       const float Pt2 = pt[tss];
 
-      const float thisChX = (charge[tss])*(charge[ts]);
+      const int thisChX = (charge[tss])*(charge[ts]);
       ////// Always require charge consistency. If different charge is assigned, do not remove seed-track
       if(thisChX<0)
 	continue;
@@ -759,19 +781,19 @@ int Event::clean_cms_seedtracks()
       ////// - 10% if track w/ 2<pT<5 GeV
       ////// - 20% if track w/ 5<pT<10 GeV
       ////// - 25% if track w/ pT>10 GeV
-      if(thisDPt>0.025*(Pt1) && Pt1<2.0 && std::abs(Eta1)<0.9)
+      if(thisDPt>dpt_brl_0*(Pt1) && Pt1<ptmax_0 && std::abs(Eta1)<etamax_brl)
 	continue;
 
-      else if(thisDPt>0.0125*(Pt1) && Pt1<2.0 && std::abs(Eta1)>0.9)
+      else if(thisDPt>dpt_ec_0*(Pt1) && Pt1<ptmax_0 && std::abs(Eta1)>etamax_brl)
 	continue;
 
-      else if(thisDPt>0.10*(Pt1) && Pt1>2.0 && Pt1<5.0) 
+      else if(thisDPt>dpt_1*(Pt1) && Pt1>ptmax_0 && Pt1<ptmax_1)
 	continue;
 
-      else if(thisDPt>0.20*(Pt1) && Pt1>5.0 && Pt1<10.0)
+      else if(thisDPt>dpt_2*(Pt1) && Pt1>ptmax_1 && Pt1<ptmax_2)
 	continue;
 
-      else if(thisDPt>0.25*(Pt1) && Pt1>10.0)
+      else if(thisDPt>dpt_3*(Pt1) && Pt1>ptmax_2)
 	continue;
 
 
@@ -802,16 +824,16 @@ int Event::clean_cms_seedtracks()
 
       ////// Reject tracks within dR-dz elliptical window.
       ////// Adaptive thresholds, based on observation that duplicates are more abundant at large pseudo-rapidity and low track pT
-      if(std::abs(Eta1)<0.9){
-	if(dz2/(0.005*0.005)+dr2/(0.010*0.010)<1.0)
+      if(std::abs(Eta1)<etamax_brl){
+	if(dz2/dzmax2_brl+dr2/drmax2_brl<1.0f)
 	  writetrack[tss]=false;	
       }
-      else if(Pt1>2.0){
-	if(dz2/(0.010*0.010)+dr2/(0.010*0.010)<1.0)
+      else if(Pt1>ptmin_hpt){
+	if(dz2/dzmax2_hpt+dr2/drmax2_hpt<1.0f)
 	  writetrack[tss]=false;
       }
       else {
-	if(dz2/(0.015*0.015)+dr2/(0.015*0.015)<1.0)
+	if(dz2/dzmax2_els+dr2/drmax2_els<1.0f)
 	  writetrack[tss]=false;
       }
 
@@ -819,7 +841,7 @@ int Event::clean_cms_seedtracks()
    
     if(writetrack[ts])
       cleanSeedTracks.emplace_back(seedTracks_[ts]);
-      
+
   }
   
 #ifdef DEBUG


### PR DESCRIPTION
Adaptive seed cleaning.
Adaptive in pT and eta of reference seed.
Criteria are based on dr-dz-dpT-charge of the seeds.
Conditions are chosen to maximize efficiency in ALL available samples, and in ALL regions of pT and eta, at the price of duplicate rate. Duplicate rate (and size of seed collection) are anyways reduced by a factor >x2 wrt. the non-cleaning scenario.

Benchmark has been run for all 3 scenarios:
- dR<0.005 (original)
- no cleaning
- new cleaning
Output of the latest and greatest benchmark scripts are available at:
http://uaf-7.t2.ucsd.edu/~mmasciov/MIC_pr116Benchmark

[NOTE: KNL benchmarking failed for 2 of the 3 scenarios (that were run in a different moment in time). Currently giving a 2nd shot, will update plots in same dir once successful.]