### PR TITLE
Script to test for compile+run in debug mode

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -225,6 +225,10 @@ else
   CPPFLAGS += -DNO_ROOT
 endif
 
+ifdef DEBUG
+  CPPFLAGS += -DDEBUG
+endif
+
 ################################################################
 # Dependency generation
 ################################################################

--- a/xeon_scripts/debug-test.sh
+++ b/xeon_scripts/debug-test.sh
@@ -1,0 +1,41 @@
+#! /bin/bash
+
+## Run this script on SNB before benchmarking and submitting a PR to ensure your new commit does not break the debug mode!
+
+## In the case this is run separately from main script
+[ -z "$ROOTSYS" ] && source ~matevz/root/bin/thisroot.sh
+source xeon_scripts/common_variables.sh
+
+## Common setup
+dir=/data/nfsmic/slava77/samples/2017/pass-4874f28/initialStep
+subdir=10muPt0p5to10HS
+file=memoryFile.fv3.clean.writeAll.recT.072617.bin
+
+## config for debug
+nevents=10
+maxth=1
+maxvu=1
+maxev=1
+
+## base executable
+exe="./mkFit/mkFit --cmssw-n2seeds --num-thr ${maxth} --num-thr-ev ${maxev} --input-file ${dir}/${subdir}/${file} --num-events ${nevents}"
+
+## Compile once
+mOpt="DEBUG:=yes WITH_ROOT:=yes USE_INTRINSICS:=-DMPT_SIZE=${maxvu}"
+make distclean ${mOpt}
+make -j 12 ${mOpt}
+
+## test each build routine to be sure it works!
+for bV in "BH bh" "STD std" "CE ce" "FV fv"
+do echo ${bV} | while read -r bN bO
+    do
+	oBase=${val_arch}_${sample}_${bN}
+	bExe="${exe} --build-${bO}"
+
+	echo "${oBase}: ${vN} [nTH:${maxth}, nVU:${maxvu}, nEV:${maxev}]"
+	${bExe} >& log_${oBase}_NVU${maxvu}_NTH${maxth}_NEV${maxev}_"DEBUG".txt
+    done
+done
+
+## clean up
+make distclean ${mOpt}


### PR DESCRIPTION
Addresses #132 : build a script that compiles the DEBUG printouts everywhere and then run a quick test over 10 events from the 10mu sample for each building routine. 

I did not include this in  ./xeon_scripts/runBenchmarks.sh as this ought to be run BEFORE, checking the log files after running to ensure everything worked. If failures in compile/running are seen with this script, it is up to the person making the PR to make the changes to compile+run before making a PR.

We have often neglected keeping up the debug statements (hidden behind ifdefs), and often, when we need to use them, we have to spend some time fixing the broken code before running the debug printouts. We can discuss this today in the meeting.

To run the script, simply do:
./xeon_scripts/debug-test.sh

Then inspect the logs:
tail log_SNB_CMSSW_TTbar_PU70_*_NVU1_NTH1_NEV1_DEBUG.txt 

and ensure everything ran properly.