### PR TITLE
Dynamic hit selection windows

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -337,6 +337,26 @@ namespace Config
   constexpr float c_dzmax_els = 0.015;
   constexpr float c_drmax_els = 0.015;
 
+  // config on hit selection windows
+  // geometry and track boundaries
+  constexpr int brl_stereoId[4] = {5,7,11,13};
+  constexpr int brl_tibId[2] = {4,9};
+  constexpr int brl_tobId[2] = {10,17};
+  constexpr int ecp_striplId[2] = {21,44};
+  constexpr int ecn_striplId[2] = {48,71};
+  constexpr float treg_eta[2] = {0.45,1.5};
+  constexpr float track_ptlow = 0.9;
+  // phi dynamic factor
+  constexpr float phif_ptlow_brl_mono       = 3.0;
+  constexpr float phif_ptlow_brl_stereo     = 2.0;
+  constexpr float phif_ptlow_treg_ec_mono   = 3.0;
+  constexpr float phif_ptlow_treg_ec_stereo = 2.0;
+  constexpr float phif_ptlow_ec_mono        = 2.0;
+  constexpr float phif_treg_ec_mono         = 1.5;
+  // q dynamic factors
+  constexpr float qf_treg_tib = 1.5;
+  constexpr float qf_treg_tob = 1.25;
+
   // Threading
   extern int    numThreadsFinder;
   extern int    numThreadsSimulation;

--- a/Geoms/CMS-2017.acc
+++ b/Geoms/CMS-2017.acc
@@ -60,8 +60,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.r_mean();
     li.set_next_layers(5, 21, 48);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 6.000;
+    li.set_selection_limits(0.01, 0.015, 6.0, 12.0);
   }
 
   {
@@ -71,8 +71,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.r_mean();
     li.set_next_layers(6, 21, 48);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 6.000;
+    li.set_selection_limits(0.023, 0.03, 6.0, 12.0);
   }
 
   {
@@ -82,8 +82,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.r_mean();
     li.set_next_layers(7, 21, 48);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 6.000;
+    li.set_selection_limits(0.01, 0.015, 6.0, 12.0);
   }
 
   {
@@ -93,8 +93,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.r_mean();
     li.set_next_layers(8, 21, 48);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 6.000;
+    li.set_selection_limits(0.016, 0.03, 6.0, 12.0);
   }
 
   {
@@ -104,8 +104,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.r_mean();
     li.set_next_layers(9, 21, 48);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 6.000;
+    li.set_selection_limits(0.01, 0.015, 6.0, 12.0);
   }
 
   {
@@ -115,8 +115,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.r_mean();
     li.set_next_layers(10, 27, 54);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 6.000;
+    li.set_selection_limits(0.01, 0.015, 6.0, 12.0);
   }
 
 
@@ -129,8 +129,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.r_mean();
     li.set_next_layers(11, 27, 54);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 9.500;
+    li.set_selection_limits(0.01, 0.015, 9.5, 19.0);
   }
 
   {
@@ -140,8 +140,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.r_mean();
     li.set_next_layers(12, 27, 54);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 9.500;
+    li.set_selection_limits(0.016, 0.03, 9.5, 19.0);
   }
 
   {
@@ -151,8 +151,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.r_mean();
     li.set_next_layers(13, 27, 54);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 9.500;
+    li.set_selection_limits(0.01, 0.015, 9.5, 19.0);
   }
 
   {
@@ -162,8 +162,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.r_mean();
     li.set_next_layers(14, 27, 54);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 9.500;
+    li.set_selection_limits(0.013, 0.03, 9.5, 19.0);
   }
 
   {
@@ -173,8 +173,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.r_mean();
     li.set_next_layers(15, 27, 54);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 9.500;
+    li.set_selection_limits(0.01, 0.015, 9.5, 19.0);
   }
 
   {
@@ -184,8 +184,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.r_mean();
     li.set_next_layers(16, 27, 54);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 9.500;
+    li.set_selection_limits(0.01, 0.015, 9.5, 19.0);
   }
 
   {
@@ -195,8 +195,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.r_mean();
     li.set_next_layers(17, 27, 54);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 9.500;
+    li.set_selection_limits(0.01, 0.015, 9.5, 19.0);
   }
 
   {
@@ -206,8 +206,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.r_mean();
     li.set_next_layers(-1, -1, -1);
     li.m_is_outer = true;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 9.500;
+    li.set_selection_limits(0.01, 0.015, 9.5, 19.0);
   }
 
 
@@ -221,7 +221,7 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.set_next_layers(4, 19, -1);
     li.m_is_outer = false;
     li.m_q_bin = 1.000;
-    li.set_selection_limits(0.01, 0.05, 0.8, 1.6);
+    li.set_selection_limits(0.01, 0.015, 0.8, 1.6);
     li.m_is_seed_lyr = true;
   }
   {
@@ -232,7 +232,7 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.set_next_layers(4, -1, 46);
     li.m_is_outer = false;
     li.m_q_bin = 1.000;
-    li.set_selection_limits(0.01, 0.05, 0.8, 1.6);
+    li.set_selection_limits(0.01, 0.015, 0.8, 1.6);
     li.m_is_seed_lyr = true;
   }
   {
@@ -243,7 +243,7 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.set_next_layers(4, 20, -1);
     li.m_is_outer = false;
     li.m_q_bin = 1.000;
-    li.set_selection_limits(0.01, 0.05, 0.8, 1.6);
+    li.set_selection_limits(0.01, 0.015, 0.8, 1.6);
     li.m_is_seed_lyr = true;
   }
   {
@@ -254,7 +254,7 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.set_next_layers(4, -1, 47);
     li.m_is_outer = false;
     li.m_q_bin = 1.000;
-    li.set_selection_limits(0.01, 0.05, 0.8, 1.6);
+    li.set_selection_limits(0.01, 0.015, 0.8, 1.6);
     li.m_is_seed_lyr = true;
   }
   {
@@ -265,7 +265,7 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.set_next_layers(4, 21, -1);
     li.m_is_outer = false;
     li.m_q_bin = 1.000;
-    li.set_selection_limits(0.01, 0.05, 0.8, 1.6);
+    li.set_selection_limits(0.01, 0.015, 0.8, 1.6);
     li.m_is_seed_lyr = true;
   }
   {
@@ -276,7 +276,7 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.set_next_layers(4, -1, 48);
     li.m_is_outer = false;
     li.m_q_bin = 1.000;
-    li.set_selection_limits(0.01, 0.05, 0.8, 1.6);
+    li.set_selection_limits(0.01, 0.015, 0.8, 1.6);
     li.m_is_seed_lyr = true;
   }
 
@@ -289,8 +289,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(10, 22, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 5.500;
+    li.set_selection_limits(0.01, 0.015, 5.5, 11.0);
   }
   {
     LayerInfo & li  = ti.m_layers[48];
@@ -299,8 +299,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(10, -1, 49);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 5.500;
+    li.set_selection_limits(0.01, 0.015, 5.5, 11.0);
   }
   {
     LayerInfo & li  = ti.m_layers[22];
@@ -309,8 +309,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(10, 23, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 5.500;
+    li.set_selection_limits(0.01, 0.03, 5.5, 11.0);
   }
   {
     LayerInfo & li  = ti.m_layers[49];
@@ -319,8 +319,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(10, -1, 50);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 5.500;
+    li.set_selection_limits(0.01, 0.03, 5.5, 11.0);
   }
   {
     LayerInfo & li  = ti.m_layers[23];
@@ -329,8 +329,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(10, 24, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 5.500;
+    li.set_selection_limits(0.01, 0.015, 5.5, 11.0);
   }
   {
     LayerInfo & li  = ti.m_layers[50];
@@ -339,8 +339,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(10, -1, 51);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 5.500;
+    li.set_selection_limits(0.01, 0.015, 5.5, 11.0);
   }
   {
     LayerInfo & li  = ti.m_layers[24];
@@ -349,8 +349,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(10, 25, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 5.500;
+    li.set_selection_limits(0.01, 0.03, 5.5, 11.0);
   }
   {
     LayerInfo & li  = ti.m_layers[51];
@@ -359,8 +359,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(10, -1, 52);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 5.500;
+    li.set_selection_limits(0.01, 0.03, 5.5, 11.0);
   }
   {
     LayerInfo & li  = ti.m_layers[25];
@@ -369,8 +369,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(10, 26, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 5.500;
+    li.set_selection_limits(0.01, 0.015, 5.5, 11.0);
   }
   {
     LayerInfo & li  = ti.m_layers[52];
@@ -379,8 +379,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(10, -1, 53);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 5.500;
+    li.set_selection_limits(0.01, 0.015, 5.5, 11.0);
   }
   {
     LayerInfo & li  = ti.m_layers[26];
@@ -389,8 +389,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(10, 27, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 5.500;
+    li.set_selection_limits(0.01, 0.03, 5.5, 11.0);
   }
   {
     LayerInfo & li  = ti.m_layers[53];
@@ -399,8 +399,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(10, -1, 54);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 5.500;
+    li.set_selection_limits(0.01, 0.03, 5.5, 11.0);
   }
 
   // TEC +/-
@@ -412,8 +412,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 28, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[54];
@@ -422,8 +422,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 55);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[28];
@@ -432,8 +432,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 29, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
     li.set_r_hole_range(42.000, 59.900);
   }
   {
@@ -443,8 +443,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 56);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
     li.set_r_hole_range(42.000, 59.900);
   }
   {
@@ -454,8 +454,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 30, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[56];
@@ -464,8 +464,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 57);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[30];
@@ -474,8 +474,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 31, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
     li.set_r_hole_range(42.000, 59.900);
   }
   {
@@ -485,8 +485,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 58);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
     li.set_r_hole_range(42.000, 59.900);
   }
   {
@@ -496,8 +496,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 32, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[58];
@@ -506,8 +506,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 59);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[32];
@@ -516,8 +516,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 33, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
     li.set_r_hole_range(42.000, 59.900);
   }
   {
@@ -527,8 +527,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 60);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
     li.set_r_hole_range(42.000, 59.900);
   }
   {
@@ -538,8 +538,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 34, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[60];
@@ -548,8 +548,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 61);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[34];
@@ -558,8 +558,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 35, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
     li.set_r_hole_range(42.100, 59.700);
   }
   {
@@ -569,8 +569,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 62);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
     li.set_r_hole_range(42.100, 59.700);
   }
   {
@@ -580,8 +580,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 36, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[62];
@@ -590,8 +590,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 63);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[36];
@@ -600,8 +600,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 37, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
     li.set_r_hole_range(42.100, 59.700);
   }
   {
@@ -611,8 +611,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 64);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
     li.set_r_hole_range(42.100, 59.700);
   }
   {
@@ -622,8 +622,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 38, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[64];
@@ -632,8 +632,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 65);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[38];
@@ -642,8 +642,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 39, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
     li.set_r_hole_range(42.100, 59.700);
   }
   {
@@ -653,8 +653,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 66);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
     li.set_r_hole_range(42.100, 59.700);
   }
   {
@@ -664,8 +664,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 40, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[66];
@@ -674,8 +674,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 67);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[40];
@@ -684,8 +684,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 41, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[67];
@@ -694,8 +694,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 68);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[41];
@@ -704,8 +704,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 42, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[68];
@@ -714,8 +714,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 69);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[42];
@@ -724,8 +724,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 43, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[69];
@@ -734,8 +734,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 70);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[43];
@@ -744,8 +744,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, 44, -1);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[70];
@@ -754,8 +754,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, 71);
     li.m_is_outer = false;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.015, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[44];
@@ -764,8 +764,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, -1);
     li.m_is_outer = true;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
   }
   {
     LayerInfo & li  = ti.m_layers[71];
@@ -774,8 +774,8 @@ void Create_CMS_2017_AutoGen(TrackerInfo& ti)
     li.m_propagate_to = li.z_mean();
     li.set_next_layers(-1, -1, -1);
     li.m_is_outer = true;
-    li.m_q_bin = 20.000;
-    li.set_selection_limits(0.01, 0.2, 10.0, 20.0);
+    li.m_q_bin = 10.000;
+    li.set_selection_limits(0.01, 0.03, 10.0, 20.0);
   }
 
 }

--- a/Geoms/CMS/make_trk_info.C
+++ b/Geoms/CMS/make_trk_info.C
@@ -75,6 +75,76 @@ void add_barrel(int &lid, int det, int lay, bool is_pix,
     ASSF(m_q_bin, 2.0);
     PRN("li.set_selection_limits(0.01, 0.05, 1.0, 2.0);");
   }
+  else if (lid==4)
+  {
+    ASSF(m_q_bin, 6.0);
+    PRN("li.set_selection_limits(0.01, 0.015, 6.0, 12.0);");
+  }
+  else if (lid==5)
+  {
+    ASSF(m_q_bin, 6.0);
+    PRN("li.set_selection_limits(0.023, 0.03, 6.0, 12.0);");
+  }
+  else if (lid==6)
+  {
+    ASSF(m_q_bin, 6.0);
+    PRN("li.set_selection_limits(0.01, 0.015, 6.0, 12.0);");
+  }
+  else if (lid==7)
+  {
+    ASSF(m_q_bin, 6.0);
+    PRN("li.set_selection_limits(0.016, 0.03, 6.0, 12.0);");
+  }
+  else if (lid==8)
+  {
+    ASSF(m_q_bin, 6.0);
+    PRN("li.set_selection_limits(0.01, 0.015, 6.0, 12.0);");
+  }
+  else if (lid==9)
+  {
+    ASSF(m_q_bin, 6.0);
+    PRN("li.set_selection_limits(0.01, 0.015, 6.0, 12.0);");
+  }
+  else if (lid==10)
+  {
+    ASSF(m_q_bin, 9.5);
+    PRN("li.set_selection_limits(0.01, 0.015, 9.5, 19.0);");
+  }
+  else if (lid==11)
+  {
+    ASSF(m_q_bin, 9.5);
+    PRN("li.set_selection_limits(0.016, 0.03, 9.5, 19.0);");
+  }
+  else if (lid==12)
+  {
+    ASSF(m_q_bin, 9.5);
+    PRN("li.set_selection_limits(0.01, 0.015, 9.5, 19.0);");
+  }
+  else if (lid==13)
+  {
+    ASSF(m_q_bin, 9.5);
+    PRN("li.set_selection_limits(0.013, 0.03, 9.5, 19.0);");
+  }
+  else if (lid==14)
+  {
+    ASSF(m_q_bin, 9.5);
+    PRN("li.set_selection_limits(0.01, 0.015, 9.5, 19.0);");
+  }
+  else if (lid==15)
+  {
+    ASSF(m_q_bin, 9.5);
+    PRN("li.set_selection_limits(0.01, 0.015, 9.5, 19.0);");
+  }
+  else if (lid==16)
+  {
+    ASSF(m_q_bin, 9.5);
+    PRN("li.set_selection_limits(0.01, 0.015, 9.5, 19.0);");
+  }
+  else if (lid==17)
+  {
+    ASSF(m_q_bin, 9.5);
+    PRN("li.set_selection_limits(0.01, 0.015, 9.5, 19.0);");
+  }
   else
   {
     ASSF(m_q_bin, 20.0);
@@ -121,10 +191,109 @@ void add_ecap(int &lid, int det, int lay, bool is_pix, bool stereo_hack,
     ASSB(m_is_outer, lid == 44);
     if (is_pix) {
       ASSF(m_q_bin, 1.0);
-      PRN("li.set_selection_limits(0.01, 0.05, 0.8, 1.6);");
-    } else {
-      ASSF(m_q_bin, 20.0);
-      PRN("li.set_selection_limits(0.01, 0.2, 10.0, 20.0);");
+      PRN("li.set_selection_limits(0.01, 0.015, 0.8, 1.6);");
+    } 
+    else {
+      if(lid==21){
+	ASSF(m_q_bin, 5.5);
+	PRN("li.set_selection_limits(0.01, 0.015, 5.5, 11.0);");
+      }
+      else if(lid==22){
+	ASSF(m_q_bin, 5.5);
+	PRN("li.set_selection_limits(0.01, 0.03, 5.5, 11.0);");
+      }
+      else if(lid==23){
+	ASSF(m_q_bin, 5.5);
+	PRN("li.set_selection_limits(0.01, 0.015, 5.5, 11.0);");
+      }
+      else if(lid==24){
+	ASSF(m_q_bin, 5.5);
+	PRN("li.set_selection_limits(0.01, 0.03, 5.5, 11.0);");
+      }
+      else if(lid==25){
+	ASSF(m_q_bin, 5.5);
+	PRN("li.set_selection_limits(0.01, 0.015, 5.5, 11.0);");
+      }
+      else if(lid==26){
+	ASSF(m_q_bin, 5.5);
+	PRN("li.set_selection_limits(0.01, 0.03, 5.5, 11.0);");
+      }
+      else if(lid==27){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==28){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==29){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==30){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==31){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==32){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==33){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==34){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==35){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==36){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==37){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==38){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==39){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==40){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==41){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==42){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==43){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==44){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else{
+	ASSF(m_q_bin, 20.0);
+	PRN("li.set_selection_limits(0.01, 0.2, 10.0, 20.0);");
+      }
     }
     if (hole_hack) {
       PRN("li.set_r_hole_range(%.3f, %.3f);", cmsDiskMinRsHole[shi], cmsDiskMaxRsHole[shi]);
@@ -147,10 +316,109 @@ void add_ecap(int &lid, int det, int lay, bool is_pix, bool stereo_hack,
     ASSB(m_is_outer, lid == 71);
     if (is_pix) {
       ASSF(m_q_bin, 1.0);
-      PRN("li.set_selection_limits(0.01, 0.05, 0.8, 1.6);");
-    } else {
-      ASSF(m_q_bin, 20.0);
-      PRN("li.set_selection_limits(0.01, 0.2, 10.0, 20.0);");
+      PRN("li.set_selection_limits(0.01, 0.015, 0.8, 1.6);");
+    } 
+    else {
+      if(lid==48){
+	ASSF(m_q_bin, 5.5);
+	PRN("li.set_selection_limits(0.01, 0.015, 5.5, 11.0);");
+      }
+      else if(lid==49){
+	ASSF(m_q_bin, 5.5);
+	PRN("li.set_selection_limits(0.01, 0.03, 5.5, 11.0);");
+      }
+      else if(lid==50){
+	ASSF(m_q_bin, 5.5);
+	PRN("li.set_selection_limits(0.01, 0.015, 5.5, 11.0);");
+      }
+      else if(lid==51){
+	ASSF(m_q_bin, 5.5);
+	PRN("li.set_selection_limits(0.01, 0.03, 5.5, 11.0);");
+      }
+      else if(lid==52){
+	ASSF(m_q_bin, 5.5);
+	PRN("li.set_selection_limits(0.01, 0.015, 5.5, 11.0);");
+      }
+      else if(lid==53){
+	ASSF(m_q_bin, 5.5);
+	PRN("li.set_selection_limits(0.01, 0.03, 5.5, 11.0);");
+      }
+      else if(lid==54){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==55){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==56){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==57){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==58){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==59){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==60){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==61){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==62){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==63){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==64){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==65){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==66){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==67){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==68){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==69){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else if(lid==70){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.015, 10.0, 20.0);");
+      }
+      else if(lid==71){
+	ASSF(m_q_bin, 10.0);
+	PRN("li.set_selection_limits(0.01, 0.03, 10.0, 20.0);");
+      }
+      else{
+	ASSF(m_q_bin, 20.0);
+	PRN("li.set_selection_limits(0.01, 0.2, 10.0, 20.0);");
+      }
     }
     if (hole_hack) {
       PRN("li.set_r_hole_range(%.3f, %.3f);", cmsDiskMinRsHole[shi], cmsDiskMaxRsHole[shi]);


### PR DESCRIPTION
Effects of such PR are described in the following google doc (pages 1-3):
https://docs.google.com/document/d/1Ug5-NWVghVs_82xkEq8a7TYklFIHlt-NDxYOdpBPFRI/edit?usp=sharing

Pages 4-5 show other interesting behaviors, based on the results of the full validation on SKL:
- Already with the original hit selection windows (--> **unrelated to this PR**), CE and STD do not exactly overlap. Hint of compilation issues?
- FV efficiency decreases significantly once the hit selection windows are updated: do not know why it should?
