### PR TITLE
Validation feature additions: clone of PR #143

### DIFF
--- a/plotting/PlotValidation.cpp
+++ b/plotting/PlotValidation.cpp
@@ -346,7 +346,7 @@ void PlotValidation::PlotFRTree()
 	    // plot names and key
 	    const TString histkey   = Form("%i_%i_d_%i_%i",j,k,p,o);
 	    const TString histname  = "h_"+dvars[p]+"_"+coll[o]+"_"+trks[j]+"_pt"+sptcuts[k];
-	    const TString histtitle = "#Delta"+sdvars[p]+"("+scoll[o]+" "+strks[j]+",CMSSW) [p_{T} > "+sptcuts[k]+" GeV/c];"+dvars[p]+"^{"+scoll[o]+" "+strks[j]+"}-"+dvars[p]+"^{CMSSW};nTracks";
+	    const TString histtitle = "#Delta"+sdvars[p]+"("+scoll[o]+" "+strks[j]+",CMSSW) [p_{T} > "+sptcuts[k]+" GeV/c];"+sdvars[p]+"^{"+scoll[o]+" "+strks[j]+"}-"+sdvars[p]+"^{CMSSW};nTracks";
 	    
 	    // Numerator only type plots only!
 	    hists[histkey] = new TH1F(histname.Data(),histtitle.Data(),dvarbins[p].size()-1,bins);
@@ -853,7 +853,7 @@ void PlotValidation::SetupStyle()
 void PlotValidation::SetupBins()
 {
   // pt bins
-  PlotValidation::SetupVariableBins("0 0.25 0.5 0.75 1 1.25 1.5 1.75 2 2.5 3 3.5 4 4.5 5 5 6 7 8 9 10 15 20 25 30 40 50",fPtBins); 
+  PlotValidation::SetupVariableBins("0 0.25 0.5 0.75 1 1.25 1.5 1.75 2 2.5 3 3.5 4 4.5 5 5 6 7 8 9 10 15 20 25 30 40 50 100",fPtBins); 
   
   // eta bins
   PlotValidation::SetupFixedBins(60,-3,3,fEtaBins);

--- a/web/collectBenchmarks.sh
+++ b/web/collectBenchmarks.sh
@@ -59,6 +59,7 @@ done
 # Move ROOT validation
 rootdir="SIMVAL"
 mkdir -p ${dir}/${rootdir}
+mkdir -p ${dir}/${rootdir}/logx
 
 for build in BH STD CE FV CMSSW
 do
@@ -68,17 +69,25 @@ done
 
 for rate in eff ineff_brl ineff_trans ineff_ec dr fr 
 do
-    for var in pt pt_zoom phi eta
-    do 
-	for pt in 0.0 0.9 2.0
-	do
+    for pt in 0.0 0.9 2.0
+    do
+	for var in phi eta
+	do 
 	    mv ${val_arch}_${sample}_${rate}_${var}_"build"_pt${pt}_"SIMVAL".png ${dir}/${rootdir}
 	done
     done
+
+    for var in pt pt_zoom
+    do 
+	mv ${val_arch}_${sample}_${rate}_${var}_"build"_pt"0.0"_"SIMVAL".png ${dir}/${rootdir}
+    done
+
+    mv ${val_arch}_${sample}_${rate}_"pt_logx"_"build"_pt"0.0"_"SIMVAL".png ${dir}/${rootdir}/logx
 done
 
 # Move CMSSW validation
 cmsswdir="CMSSWVAL"
+mkdir -p ${dir}/${cmsswdir}
 mkdir -p ${dir}/${cmsswdir}
 
 for build in BH STD CE FV
@@ -89,21 +98,28 @@ done
 
 for trk in build fit
 do
-    mkdir -p ${dir}/${cmsswdir}/${trk}
+    mkdir -p ${dir}/${cmsswdir}/${trk}/logx
     mkdir -p ${dir}/${cmsswdir}/${trk}/diffs
 done
 
 for rate in eff ineff_brl ineff_trans ineff_ec dr fr 
 do
-    for var in pt pt_zoom phi eta
+    for trk in build fit
     do
-	for trk in build fit
+	for pt in 0.0 0.9 2.0
 	do
-	    for pt in 0.0 0.9 2.0
+	    for var in phi eta
 	    do
 		mv ${val_arch}_${sample}_${rate}_${var}_${trk}_pt${pt}_"CMSSWVAL".png ${dir}/${cmsswdir}/${trk}
 	    done
 	done
+
+	for var in pt pt_zoom
+	do
+	    mv ${val_arch}_${sample}_${rate}_${var}_${trk}_pt"0.0"_"CMSSWVAL".png ${dir}/${cmsswdir}/${trk}
+	done
+	
+	mv ${val_arch}_${sample}_${rate}_"pt_logx"_${trk}_pt"0.0"_"CMSSWVAL".png ${dir}/${cmsswdir}/${trk}/logx
     done
 done    
 


### PR DESCRIPTION
Took the opportunity to squash the five commits from PR #143 into one. 

Changes include:
	 * Add mean of kinematic diff plots in cmssw validation to legends
	 * Add logx directory for logx version of rates vs pT, expanded range to 100 GeV
	 * Fixed axis titles in diff plots, add workaround for disappearing titles dues to logx
	 * Remove pT > 0.9, 2.0 from output director for pT vs rate plots

I will run the validation with the old configuration and post the plots here.