### PR TITLE
Update ranges in benchmarks, add common style function

### DIFF
--- a/plotting/Common.hh
+++ b/plotting/Common.hh
@@ -13,6 +13,16 @@
 #include <iostream>
 #include <vector>
 
+namespace
+{
+  void setupStyle()
+  {
+    gStyle->SetOptStat(0);
+    gStyle->SetPadTickX(1);
+    gStyle->SetPadTickY(1);
+  }
+};
+
 enum ArchEnum {SNB, KNL, SKL};
 
 struct BuildOpts
@@ -77,7 +87,7 @@ namespace
       arch_opt.thmax = 24;
       
       arch_opt.vutimemin = 0.;
-      arch_opt.vutimemax = 1.;
+      arch_opt.vutimemax = 0.5;
 
       arch_opt.thtimemin = 0.001;
       arch_opt.thtimemax = 1.;
@@ -88,7 +98,7 @@ namespace
       arch_opt.thspeedupmin = 0.;
       arch_opt.thspeedupmax = arch_opt.thmax;
 
-      arch_opt.thmeiftimemin = 0.02;
+      arch_opt.thmeiftimemin = 0.01;
       arch_opt.thmeiftimemax = 0.5;
 
       arch_opt.thmeifspeedupmin = 0.;
@@ -103,7 +113,7 @@ namespace
       arch_opt.thmax = 256;
 
       arch_opt.vutimemin = 0.;
-      arch_opt.vutimemax = 2.;
+      arch_opt.vutimemax = 1.5;
 
       arch_opt.thtimemin = 0.001;
       arch_opt.thtimemax = 1.;
@@ -129,7 +139,7 @@ namespace
       arch_opt.thmax = 64;
 
       arch_opt.vutimemin = 0.;
-      arch_opt.vutimemax = 2.;
+      arch_opt.vutimemax = 0.25;
 
       arch_opt.thtimemin = 0.001;
       arch_opt.thtimemax = 1.;
@@ -138,13 +148,13 @@ namespace
       arch_opt.vuspeedupmax = arch_opt.vumax;
 
       arch_opt.thspeedupmin = 0.;
-      arch_opt.thspeedupmax = arch_opt.thmax;
+      arch_opt.thspeedupmax = arch_opt.thmax / 2;
 
       arch_opt.thmeiftimemin = 0.001;
       arch_opt.thmeiftimemax = arch_opt.thtimemax;
 
       arch_opt.thmeifspeedupmin = 0.;
-      arch_opt.thmeifspeedupmax = arch_opt.thmax;
+      arch_opt.thmeifspeedupmax = arch_opt.thspeedupmax;
     }
   }
 };

--- a/plotting/PlotBenchmarks.cpp
+++ b/plotting/PlotBenchmarks.cpp
@@ -4,7 +4,8 @@
 
 PlotBenchmarks::PlotBenchmarks(const TString & arch, const TString & sample) : arch(arch), sample(sample)
 {
-  gStyle->SetOptStat(0);
+  // setup style for plotting
+  setupStyle();
 
   // get file
   file = TFile::Open("benchmark_"+arch+"_"+sample+".root");

--- a/plotting/PlotMEIFBenchmarks.cpp
+++ b/plotting/PlotMEIFBenchmarks.cpp
@@ -3,7 +3,8 @@
 PlotMEIFBenchmarks::PlotMEIFBenchmarks(const TString & arch, const TString & sample, const TString &  build)
   : arch(arch), sample(sample), build(build)
 {
-  gStyle->SetOptStat(0);
+  // setup style for plotting
+  setupStyle();
 
   // get file
   file = TFile::Open("benchmarkMEIF_"+arch+"_"+sample+"_"+build+".root");

--- a/plotting/PlotsFromDump.cpp
+++ b/plotting/PlotsFromDump.cpp
@@ -2,7 +2,8 @@
 
 PlotsFromDump::PlotsFromDump(const TString & sample, const TString & build) : sample(sample), build(build)
 {
-  gStyle->SetOptStat(0);
+  // setup style for plotting
+  setupStyle();
 
   // Setup build opts
   setupBuilds(false);

--- a/plotting/StackValidation.cpp
+++ b/plotting/StackValidation.cpp
@@ -2,7 +2,8 @@
 
 StackValidation::StackValidation(const TString & label, const TString & extra, const Bool_t cmsswComp) : label(label), extra(extra), cmsswComp(cmsswComp)
 {
-  gStyle->SetOptStat(0);
+  // setup style for plotting
+  setupStyle();
 
   // setup builds --> if simvalidation, add cmssw tracks to validation
   setupBuilds(!cmsswComp);


### PR DESCRIPTION
Minor changes to benchmarks + validation: 
- updated y-axis ranges for various benchmarks to zoom in on interesting regions (and see full range for MEIF on SNB)
- add a common style function called for all the plotting tools + add in tick marks on x,y axes

benchmark plots (made with this HEAD of devel + this PR): https://kmcdermo.web.cern.ch/kmcdermo/update_range