### PR TITLE
Handle input hit phi outside of (-pi,pi) during hit binning

### DIFF
--- a/Hit.h
+++ b/Hit.h
@@ -19,6 +19,11 @@ inline float squashPhiGeneral(float phi)
   return phi - floor(0.5*Config::InvPI*(phi+Config::PI)) * Config::TwoPI;
 }
 
+inline float squashPhiMinimal(float phi)
+{
+   return phi >= Config::PI ? phi - Config::TwoPI : (phi < -Config::PI ? phi + Config::TwoPI : phi);
+}
+
 // moved from config to here
 inline int getEtaBin(float eta)
 {

--- a/mkFit/HitStructures.cc
+++ b/mkFit/HitStructures.cc
@@ -159,7 +159,7 @@ void LayerOfHits::SuckInHits(const HitVec &hitv)
     }
 
     // N.1.b ha[j].phi is returned by atan2 and can be rounded the wrong way, resulting in bin -1 or Config::m_nphi
-    int phi_bin = std::min(std::max(GetPhiBin(ha[j].phi), 0), Config::m_nphi - 1);
+    int phi_bin = clamp(GetPhiBin(ha[j].phi), 0, Config::m_nphi - 1);
 
     if (phi_bin > curr_phi_bin)
     {

--- a/mkFit/HitStructures.cc
+++ b/mkFit/HitStructures.cc
@@ -100,6 +100,7 @@ void LayerOfHits::SuckInHits(const HitVec &hitv)
     for (auto const &h : hitv)
     {
       HitInfo &hi = ha[i];
+      // N.1.a For phi in [-pi, pi): squashPhiMinimal(h.phi()); Apparently atan2 can round the wrong way.
       hi.phi  = h.phi();
       hi.q    = is_brl ? h.z() : h.r();
       hi.qbin = std::max(std::min(static_cast<int>((hi.q - m_qmin) * m_fq), m_nq - 1), 0);
@@ -157,7 +158,8 @@ void LayerOfHits::SuckInHits(const HitVec &hitv)
       curr_phi_bin = 0;
     }
 
-    int phi_bin = GetPhiBinChecked(ha[j].phi);
+    // N.1.b ha[j].phi is returned by atan2 and can be rounded the wrong way, resulting in bin -1 or Config::m_nphi
+    int phi_bin = std::min(std::max(GetPhiBin(ha[j].phi), 0), Config::m_nphi - 1);
 
     if (phi_bin > curr_phi_bin)
     {

--- a/mkFit/HitStructures.cc
+++ b/mkFit/HitStructures.cc
@@ -157,7 +157,7 @@ void LayerOfHits::SuckInHits(const HitVec &hitv)
       curr_phi_bin = 0;
     }
 
-    int phi_bin = GetPhiBin(ha[j].phi);
+    int phi_bin = GetPhiBinChecked(ha[j].phi);
 
     if (phi_bin > curr_phi_bin)
     {

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -191,8 +191,10 @@ public:
 
   int   GetQBinChecked(float q) const { int qb = GetQBin(q); if (qb < 0) qb = 0; else if (qb >= m_nq) qb = m_nq - 1; return qb; }
 
-  // if you don't pass phi in (-pi, +pi), mask away the upper bits using m_phi_mask
+  // If you don't pass phi in (-pi, +pi), mask away the upper bits using m_phi_mask or use the Checked version.
   int   GetPhiBin(float phi) const { return std::floor(m_fphi * (phi + Config::PI)); }
+
+  int   GetPhiBinChecked(float phi) const { return GetPhiBin(phi) & m_phi_mask; }
 
   const vecPhiBinInfo_t& GetVecPhiBinInfo(float q) const { return m_phi_bin_infos[GetQBin(q)]; }
 


### PR DESCRIPTION
This was observed with recent data (CCC) but it is likely it was there before.