### PR TITLE
fix energy loss in backward propagation

### DIFF
--- a/mkFit/PropagationMPlex.h
+++ b/mkFit/PropagationMPlex.h
@@ -49,7 +49,7 @@ void helixAtZ(const MPlexLV& inPar,  const MPlexQI& inChg, const MPlexQF &msZ,
                     MPlexLV& outPar,       MPlexLL& errorProp,
               const int      N_proc, const PropagationFlags pflags);
 
-void applyMaterialEffects(const MPlexQF &hitsRl, const MPlexQF& hitsXi, 
+void applyMaterialEffects(const MPlexQF &hitsRl, const MPlexQF& hitsXi, const MPlexQF& propSign,
                                 MPlexLS &outErr,       MPlexLV& outPar,
                           const int      N_proc);
 


### PR DESCRIPTION
This pull request fixes the sign of the energy loss in backward propagation (i.e. the particle energy is increased when going backwards).

It seems to me this does not affect the score tail, but maybe it will improve a bit the backward fitting.

