### PR TITLE
Remove duplicates

### DIFF
--- a/Config.cc
+++ b/Config.cc
@@ -80,6 +80,8 @@ namespace Config
   bool  readSimTrackStates = false;
   bool  inclusiveShorts = false;
   bool  keepHitInfo = false;
+  bool  useHitsForDuplicates = false;
+  bool  removeDuplicates = true;
   bool  tryToSaveSimInfo = false;
   matchOpts cmsswMatchingFW = hitBased;
   matchOpts cmsswMatchingBK = trkParamBased;

--- a/Config.cc
+++ b/Config.cc
@@ -80,11 +80,16 @@ namespace Config
   bool  readSimTrackStates = false;
   bool  inclusiveShorts = false;
   bool  keepHitInfo = false;
-  bool  useHitsForDuplicates = true;
-  bool  removeDuplicates = false;
   bool  tryToSaveSimInfo = false;
   matchOpts cmsswMatchingFW = hitBased;
   matchOpts cmsswMatchingBK = trkParamBased;
+
+  bool  removeDuplicates = true;
+  bool  useHitsForDuplicates = true;
+  float maxdPhi = 0.1;
+  float maxdPt  = 0.05;
+  float maxdEta = 0.2;
+  float minFracHitsShared = 0.75;
 
   bool mtvLikeValidation = false;
   int  cmsSelMinLayers = 12;

--- a/Config.cc
+++ b/Config.cc
@@ -84,7 +84,7 @@ namespace Config
   matchOpts cmsswMatchingFW = hitBased;
   matchOpts cmsswMatchingBK = trkParamBased;
 
-  bool  removeDuplicates = true;
+  bool  removeDuplicates = false;
   bool  useHitsForDuplicates = true;
   float maxdPhi = 0.1;
   float maxdPt  = 0.05;

--- a/Config.cc
+++ b/Config.cc
@@ -80,7 +80,7 @@ namespace Config
   bool  readSimTrackStates = false;
   bool  inclusiveShorts = false;
   bool  keepHitInfo = false;
-  bool  useHitsForDuplicates = false;
+  bool  useHitsForDuplicates = true;
   bool  removeDuplicates = false;
   bool  tryToSaveSimInfo = false;
   matchOpts cmsswMatchingFW = hitBased;

--- a/Config.h
+++ b/Config.h
@@ -320,6 +320,8 @@ namespace Config
   extern bool readSimTrackStates; // need this to fill pulls
   extern bool inclusiveShorts;
   extern bool keepHitInfo;
+  extern bool useHitsForDuplicates;
+  extern bool removeDuplicates;
   extern bool tryToSaveSimInfo;
   extern matchOpts cmsswMatchingFW;
   extern matchOpts cmsswMatchingBK;

--- a/Config.h
+++ b/Config.h
@@ -320,11 +320,17 @@ namespace Config
   extern bool readSimTrackStates; // need this to fill pulls
   extern bool inclusiveShorts;
   extern bool keepHitInfo;
-  extern bool useHitsForDuplicates;
-  extern bool removeDuplicates;
   extern bool tryToSaveSimInfo;
   extern matchOpts cmsswMatchingFW;
   extern matchOpts cmsswMatchingBK;
+
+  // config on duplicate removal
+  extern bool useHitsForDuplicates;
+  extern bool removeDuplicates;
+  extern float maxdPhi;
+  extern float maxdPt;
+  extern float maxdEta;
+  extern float minFracHitsShared;
 
   // config on seed cleaning
   constexpr int minNHits_seedclean = 4;

--- a/TTreeValidation.cc
+++ b/TTreeValidation.cc
@@ -1752,7 +1752,7 @@ void TTreeValidation::fillFakeRateTree(const Event& ev)
     {
       mcmask_seed_FR_ = -2;
     }
-    else if
+    else
     {
       if (Config::inclusiveShorts) 
       {
@@ -1892,7 +1892,7 @@ void TTreeValidation::fillFakeRateTree(const Event& ev)
       { 
 	mcmask_build_FR_ = -2;
       }
-      else if
+      else
       {
 	if (Config::inclusiveShorts) 
         {
@@ -2078,7 +2078,7 @@ void TTreeValidation::fillFakeRateTree(const Event& ev)
       { 
 	mcmask_fit_FR_ = -2;
       }
-      else if 
+      else
       {
 	if (Config::inclusiveShorts) 
         {
@@ -2651,7 +2651,7 @@ void TTreeValidation::fillCMSSWFakeRateTree(const Event& ev)
     { 
       cmsswmask_build_cFR_ = -2;
     }
-    else if
+    else
     {
       if (Config::inclusiveShorts) 
       {

--- a/TTreeValidation.cc
+++ b/TTreeValidation.cc
@@ -1185,6 +1185,10 @@ int TTreeValidation::getMaskAssignment(const int refID)
   {
     refmask = 1; // matched track to sim
   }
+  else if( refID == -10)
+  {
+    refmask = -2;
+  }
   else 
   {
     if (Config::inclusiveShorts) // only used by standard simval!

--- a/TTreeValidation.cc
+++ b/TTreeValidation.cc
@@ -1748,7 +1748,11 @@ void TTreeValidation::fillFakeRateTree(const Event& ev)
     {
       mcmask_seed_FR_ = 1; // matched track to sim
     }
-    else 
+    else if (mcID_seed_FR_ == -10) //duplicate track
+    {
+      mcmask_seed_FR_ = -2;
+    }
+    else if
     {
       if (Config::inclusiveShorts) 
       {
@@ -1884,7 +1888,11 @@ void TTreeValidation::fillFakeRateTree(const Event& ev)
       {
 	mcmask_build_FR_ = 1; // matched track to sim
       }
-      else 
+      else if (mcID_build_FR_ == -10) //duplicate track
+      { 
+	mcmask_build_FR_ = -2;
+      }
+      else if
       {
 	if (Config::inclusiveShorts) 
         {
@@ -2066,7 +2074,11 @@ void TTreeValidation::fillFakeRateTree(const Event& ev)
       {
 	mcmask_fit_FR_ = 1; // matched track to sim
       }
-      else 
+      else if (mcID_fit_FR_ == -10) //duplicate track
+      { 
+	mcmask_fit_FR_ = -2;
+      }
+      else if 
       {
 	if (Config::inclusiveShorts) 
         {
@@ -2635,7 +2647,11 @@ void TTreeValidation::fillCMSSWFakeRateTree(const Event& ev)
     {
       cmsswmask_build_cFR_ = 1; 
     }
-    else 
+    else if (cmsswID_build_cFR_ == -10) //duplicate track
+    { 
+      cmsswmask_build_cFR_ = -2;
+    }
+    else if
     {
       if (Config::inclusiveShorts) 
       {
@@ -2753,6 +2769,10 @@ void TTreeValidation::fillCMSSWFakeRateTree(const Event& ev)
       if (cmsswID_fit_cFR_ >= 0) // matched track to cmssw 
       {
 	cmsswmask_fit_cFR_ = 1; 
+      }
+      else if (cmsswID_fit_cFR_ == -10) //duplicate track
+      {
+	cmsswmask_fit_cFR_ = -2;
       }
       else 
       {

--- a/Track.cc
+++ b/Track.cc
@@ -284,42 +284,49 @@ bool TrackExtra::isSeedHit(const int lyr, const int idx) const
 	  != matchedSeedHits_.end());
 }
 
-int TrackExtra::modifyRefTrackID(const int foundHits, const int minHits, const TrackVec& reftracks, const int trueID, int refTrackID)
+  int TrackExtra::modifyRefTrackID(const int foundHits, const int minHits, const TrackVec& reftracks, const int trueID, const int duplicate, int refTrackID)
 {
   // Modify refTrackID based on nMinHits and findability
-  if (refTrackID >= 0)
+  if(duplicate)
   {
-    if (reftracks[refTrackID].isFindable()) 
-    {
-      if (foundHits < minHits) refTrackID = -2;
-      else                     refTrackID = refTrackID;
-    }
-    else // ref track is not findable
-    {
-      if (foundHits < minHits) refTrackID = -3;
-      else                     refTrackID = -4;
-    }
+    refTrackID = -10;
   }
-  else if (refTrackID == -1)
+  else
   {
-    if (trueID >= 0)
-    {
-      if (reftracks[trueID].isFindable()) 
+    if (refTrackID >= 0)
       {
-	if (foundHits < minHits) refTrackID = -5;
-	else                     refTrackID = refTrackID;
+	if (reftracks[refTrackID].isFindable()) 
+	  {
+	    if (foundHits < minHits) refTrackID = -2;
+	    else                     refTrackID = refTrackID;
+	  }
+	else // ref track is not findable
+	  {
+	    if (foundHits < minHits) refTrackID = -3;
+      else                     refTrackID = -4;
+	  }
       }
-      else // sim track is not findable
+    else if (refTrackID == -1)
       {
-	if (foundHits < minHits) refTrackID = -6;
-	else                     refTrackID = -7;
+	if (trueID >= 0)
+	  {
+	    if (reftracks[trueID].isFindable()) 
+	      {
+		if (foundHits < minHits) refTrackID = -5;
+		else                     refTrackID = refTrackID;
+	      }
+	    else // sim track is not findable
+	      {
+		if (foundHits < minHits) refTrackID = -6;
+		else                     refTrackID = -7;
+	      }
+	  }
+	else
+	  {
+	    if (foundHits < minHits) refTrackID = -8;
+	    else                     refTrackID = -9;
+	  }
       }
-    }
-    else
-    {
-      if (foundHits < minHits) refTrackID = -8;
-      else                     refTrackID = -9;
-    }
   }
   return refTrackID;
 }
@@ -437,8 +444,7 @@ void TrackExtra::setMCTrackIDInfo(const Track& trk, const std::vector<HitVec>& l
   // Modify mcTrackID based on length of track (excluding seed tracks, of course) and findability
   if (!isSeed)
   {
-    mcTrackID_ = modifyRefTrackID(trk.nFoundHits()-nSeedHits,Config::nMinFoundHits-nSeedHits,simtracks,(isPure?seedID_:-1),mcTrackID_);
-    if(trk.getDuplicateValue()) mcTrackID_ = -10;
+    mcTrackID_ = modifyRefTrackID(trk.nFoundHits()-nSeedHits,Config::nMinFoundHits-nSeedHits,simtracks,(isPure?seedID_:-1),trk.getDuplicateValue(),mcTrackID_);
   }
 
   dprint("Track " << trk.label() << " best mc track " << mcTrackID_ << " count " << mccount << "/" << trk.nFoundHits());
@@ -557,7 +563,7 @@ void TrackExtra::setCMSSWTrackIDInfoByTrkParams(const Track& trk, const std::vec
   const int nSeedHits = nMatchedSeedHits();
 
   // Modify cmsswTrackID based on length and findability
-  cmsswTrackID_ = modifyRefTrackID(trk.nFoundHits()-nSeedHits,Config::nMinFoundHits-nSeedHits,cmsswtracks,-1,cmsswTrackID_);
+  cmsswTrackID_ = modifyRefTrackID(trk.nFoundHits()-nSeedHits,Config::nMinFoundHits-nSeedHits,cmsswtracks,-1,trk.getDuplicateValue(),cmsswTrackID_);
 
   // other important info
   nHitsMatched_ = nHitsMatched;
@@ -710,7 +716,7 @@ void TrackExtra::setCMSSWTrackIDInfoByHits(const Track& trk, const LayIdxIDVecMa
   const int nSeedHits = nMatchedSeedHits();
 
   // Modify cmsswTrackID based on length and findability
-  cmsswTrackID_ = modifyRefTrackID(trk.nFoundHits()-nSeedHits,Config::nMinFoundHits-nSeedHits,cmsswtracks,cmsswlabel,cmsswTrackID_);
+  cmsswTrackID_ = modifyRefTrackID(trk.nFoundHits()-nSeedHits,Config::nMinFoundHits-nSeedHits,cmsswtracks,cmsswlabel,trk.getDuplicateValue(),cmsswTrackID_);
 
   // other important info
   fracHitsMatched_ = (cmsswTrackID >=0 ? (float(nHitsMatched_) / float(cmsswtracks[cmsswTrackID].nUniqueLayers(false)-cmsswextras[cmsswTrackID].nMatchedSeedHits())) : 0.f);

--- a/Track.cc
+++ b/Track.cc
@@ -284,7 +284,7 @@ bool TrackExtra::isSeedHit(const int lyr, const int idx) const
 	  != matchedSeedHits_.end());
 }
 
-  int TrackExtra::modifyRefTrackID(const int foundHits, const int minHits, const TrackVec& reftracks, const int trueID, const int duplicate, int refTrackID)
+ int TrackExtra::modifyRefTrackID(const int foundHits, const int minHits, const TrackVec& reftracks, const int trueID, const int duplicate, int refTrackID)
 {
   // Modify refTrackID based on nMinHits and findability
   if(duplicate)

--- a/Track.cc
+++ b/Track.cc
@@ -438,6 +438,7 @@ void TrackExtra::setMCTrackIDInfo(const Track& trk, const std::vector<HitVec>& l
   if (!isSeed)
   {
     mcTrackID_ = modifyRefTrackID(trk.nFoundHits()-nSeedHits,Config::nMinFoundHits-nSeedHits,simtracks,(isPure?seedID_:-1),mcTrackID_);
+    if(trk.getDuplicateValue()) mcTrackID_ = -10;
   }
 
   dprint("Track " << trk.label() << " best mc track " << mcTrackID_ << " count " << mccount << "/" << trk.nFoundHits());

--- a/Track.h
+++ b/Track.h
@@ -616,7 +616,7 @@ public:
   TrackExtra() : seedID_(std::numeric_limits<int>::max()) {}
   TrackExtra(int seedID) : seedID_(seedID) {}
 
-  int  modifyRefTrackID(const int foundHits, const int minHits, const TrackVec& reftracks, const int trueID, int refTrackID);
+  int  modifyRefTrackID(const int foundHits, const int minHits, const TrackVec& reftracks, const int trueID, const int duplicate, int refTrackID);
   void setMCTrackIDInfo(const Track& trk, const std::vector<HitVec>& layerHits, const MCHitInfoVec& globalHitInfo, const TrackVec& simtracks, 
 			const bool isSeed, const bool isPure);
   void setCMSSWTrackIDInfoByTrkParams(const Track& trk, const std::vector<HitVec>& layerHits, const TrackVec& cmsswtracks, const RedTrackVec& redcmsswtracks,

--- a/Track.h
+++ b/Track.h
@@ -418,7 +418,7 @@ public:
         // Set to true when number of holes would exceed an external limit, Config::maxHolesPerCand.
         // XXXXMT Not used yet, -2 last hit idx is still used! Need to add it to MkFi**r classes.
         // Problem is that I have to carry bits in/out of the MkFinder, too.
-	//        bool stopped : 1;
+	bool stopped : 1;
 
         // Production type (most useful for sim tracks): 0, 1, 2, 3 for unset, signal, in-time PU, oot PU
         unsigned int prod_type : 2;
@@ -437,7 +437,7 @@ public:
 	bool duplicate : 1;
 
         // The rest, testing if mixing int and unsigned int is ok.
-        int          _some_free_bits_ : 4;
+        int          _some_free_bits_ : 3;
         unsigned int _more_free_bits_ : 6;
 
       };

--- a/Track.h
+++ b/Track.h
@@ -418,7 +418,7 @@ public:
         // Set to true when number of holes would exceed an external limit, Config::maxHolesPerCand.
         // XXXXMT Not used yet, -2 last hit idx is still used! Need to add it to MkFi**r classes.
         // Problem is that I have to carry bits in/out of the MkFinder, too.
-        bool stopped : 1;
+	//        bool stopped : 1;
 
         // Production type (most useful for sim tracks): 0, 1, 2, 3 for unset, signal, in-time PU, oot PU
         unsigned int prod_type : 2;
@@ -432,6 +432,9 @@ public:
 
 	// Candidate score for ranking (12 bits for value + 1 bit for sign):
 	int cand_score : 15;
+
+	//Whether or not the track matched to another track and had the lower cand score
+	bool duplicate : 1;
 
         // The rest, testing if mixing int and unsigned int is ok.
         int          _some_free_bits_ : 4;
@@ -462,7 +465,8 @@ public:
 
   void setCandScore(int r) { status_.cand_score = r; }
   int getCandScore() const { return status_.cand_score; }
-
+  void setDuplicateValue(bool d) {status_.duplicate = d;}
+  bool getDuplicateValue() const {return status_.duplicate;}
   enum class ProdType { NotSet = 0, Signal = 1, InTimePU = 2, OutOfTimePU = 3};
   ProdType prodType()  const { return ProdType(status_.prod_type); }
   void setProdType(ProdType ptyp) { status_.prod_type = static_cast<unsigned int>(ptyp); }

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -1261,7 +1261,7 @@ void MkBuilder::score_tracks(TrackVec& tracks)
 void MkBuilder::find_duplicates(TrackVec& tracks)
 {
   const auto ntracks = tracks.size();
-  for (auto itrack = 0U; itrack < ntracks-1; itrack++))
+  for (auto itrack = 0U; itrack < ntracks-1; itrack++)
   {
     auto & track = tracks[itrack];
     float eta1 = track.momEta();
@@ -1320,7 +1320,7 @@ void MkBuilder::find_duplicates(TrackVec& tracks)
 void MkBuilder::remove_duplicates(TrackVec & tracks)
 {
   tracks.erase(std::remove_if(tracks.begin(),tracks.end(),
-			      [](){return track.status.duplicate;}),tracks.end());
+			      [](auto track){return track.getDuplicateValue();}),tracks.end());
 }
 
 //------------------------------------------------------------------------------

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -1331,6 +1331,32 @@ void MkBuilder::remove_duplicates(TrackVec & tracks)
 			      [](auto track){return track.getDuplicateValue();}),tracks.end());
 }
 
+void MkBuilder::handle_duplicates()
+{
+  //Mark tracks as duplicates; if within CMSSW, remove duplicate tracks from fit or candidate track collection
+  if (Config::removeDuplicates)
+  {
+    if (Config::quality_val || Config::sim_val || Config::cmssw_val)
+    {
+      find_duplicates(m_event->candidateTracks_);
+      find_duplicates(m_event->fitTracks_);
+    }
+    else if ( Config::cmssw_export)
+    {
+      if (Config::backwardFit)
+      {
+	find_duplicates(m_event->fitTracks_);
+	remove_duplicates(m_event->fitTracks_);
+      }
+      else
+      {
+	find_duplicates(m_event->candidateTracks_);
+	remove_duplicates(m_event->candidateTracks_);
+      }
+    } 
+  }
+}
+
 //------------------------------------------------------------------------------
 // PrepareSeeds
 //------------------------------------------------------------------------------

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -1133,8 +1133,6 @@ void MkBuilder::root_val()
 
 void MkBuilder::cmssw_export()
 {
-  if(Config::removeDuplicates) remove_duplicates(m_event->candidateTracks_);
-  
   // get the tracks ready for export
   remap_track_hits(m_event->candidateTracks_);
   if(Config::backwardFit) {

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -952,7 +952,6 @@ void MkBuilder::quality_store_tracks(TrackVec& tracks)
 
       if (std::isnan(bcand.chi2())) ++chi2_nan_cnt;
       if (bcand.chi2() > 500)       ++chi2_500_cnt;
-      //      if (bcand.getDuplicateValue()) {std::cout<<"Duplicate!" << std::endl;continue;}
 
       tracks.push_back(bcand);
 

--- a/mkFit/MkBuilder.h
+++ b/mkFit/MkBuilder.h
@@ -172,7 +172,8 @@ public:
   void prep_tracks(TrackVec& tracks, TrackExtraVec& extras, const bool realigntracks); // sort hits by layer, init track extras, align track labels if true
   void score_tracks(TrackVec& tracks); // if track score not already assigned
 
-  TrackVec remove_duplicates(TrackVec& tracks);
+  void find_duplicates(TrackVec& tracks);
+  void remove_duplicates(TrackVec& tracks);
 
   // --------
 

--- a/mkFit/MkBuilder.h
+++ b/mkFit/MkBuilder.h
@@ -172,6 +172,8 @@ public:
   void prep_tracks(TrackVec& tracks, TrackExtraVec& extras, const bool realigntracks); // sort hits by layer, init track extras, align track labels if true
   void score_tracks(TrackVec& tracks); // if track score not already assigned
 
+  TrackVec remove_duplicates(TrackVec& tracks);
+
   // --------
 
   void find_tracks_load_seeds_BH(); // for FindTracksBestHit

--- a/mkFit/MkBuilder.h
+++ b/mkFit/MkBuilder.h
@@ -174,6 +174,7 @@ public:
 
   void find_duplicates(TrackVec& tracks);
   void remove_duplicates(TrackVec& tracks);
+  void handle_duplicates();
 
   // --------
 

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -272,6 +272,7 @@ double runBuildingTestPlexStandard(Event& ev, MkBuilder& builder)
   if (Config::quality_val || Config::sim_val || Config::cmssw_val || Config::cmssw_export)
   {
     builder.quality_store_tracks(ev.candidateTracks_);
+    if(Config::removeDuplicates) builder.find_duplicates(ev.candidateTracks_);
   }
 
   // now do backwards fit... do we want to time this section?
@@ -336,6 +337,7 @@ double runBuildingTestPlexCloneEngine(Event& ev, MkBuilder& builder)
   if (Config::quality_val || Config::sim_val || Config::cmssw_val || Config::cmssw_export)
   {
     builder.quality_store_tracks(ev.candidateTracks_);
+    if(Config::removeDuplicates) builder.find_duplicates(ev.candidateTracks_);
   }
 
   // now do backwards fit... do we want to time this section?

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -282,12 +282,6 @@ double runBuildingTestPlexStandard(Event& ev, MkBuilder& builder)
   if (Config::quality_val || Config::sim_val || Config::cmssw_val || Config::cmssw_export)
   {
     builder.quality_store_tracks(ev.candidateTracks_);
-    //Mark tracks as duplicates; if within CMSSW, remove duplicate tracks before backward fit
-    if(Config::removeDuplicates) 
-    {
-      builder.find_duplicates(ev.candidateTracks_);
-      if(Config::cmssw_export) builder.remove_duplicates(ev.candidateTracks_);
-    }
   }
 
   // now do backwards fit... do we want to time this section?
@@ -302,6 +296,8 @@ double runBuildingTestPlexStandard(Event& ev, MkBuilder& builder)
       builder.quality_store_tracks(ev.fitTracks_);
     }
   }
+
+  builder.handle_duplicates();
 
   // validation section
   if        (Config::quality_val) {
@@ -352,12 +348,6 @@ double runBuildingTestPlexCloneEngine(Event& ev, MkBuilder& builder)
   if (Config::quality_val || Config::sim_val || Config::cmssw_val || Config::cmssw_export)
   {
     builder.quality_store_tracks(ev.candidateTracks_);
-    //Mark tracks as duplicates; if within CMSSW, remove duplicate tracks before backward fit
-    if(Config::removeDuplicates)
-    {
-      builder.find_duplicates(ev.candidateTracks_);
-      if(Config::cmssw_export) builder.remove_duplicates(ev.candidateTracks_);
-    }
   }
 
   // now do backwards fit... do we want to time this section?
@@ -372,6 +362,8 @@ double runBuildingTestPlexCloneEngine(Event& ev, MkBuilder& builder)
       builder.quality_store_tracks(ev.fitTracks_);
     }
   }
+
+  builder.handle_duplicates();
 
   // validation section
   if        (Config::quality_val) {
@@ -420,12 +412,6 @@ double runBuildingTestPlexFV(Event& ev, MkBuilder& builder)
   if (Config::quality_val || Config::sim_val || Config::cmssw_val || Config::cmssw_export)
   {
     builder.quality_store_tracks(ev.candidateTracks_);
-    //Mark tracks as duplicates; if within CMSSW, remove duplicate tracks before backward fit  
-    if(Config::removeDuplicates)
-    {
-      builder.find_duplicates(ev.candidateTracks_);
-      if(Config::cmssw_export) builder.remove_duplicates(ev.candidateTracks_);
-    }
   }
 
   // now do backwards fit... do we want to time this section?
@@ -438,6 +424,8 @@ double runBuildingTestPlexFV(Event& ev, MkBuilder& builder)
       builder.quality_store_tracks(ev.fitTracks_);
     }
   }
+
+  builder.handle_duplicates();
 
   // validation section
   if        (Config::quality_val) {

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -272,7 +272,12 @@ double runBuildingTestPlexStandard(Event& ev, MkBuilder& builder)
   if (Config::quality_val || Config::sim_val || Config::cmssw_val || Config::cmssw_export)
   {
     builder.quality_store_tracks(ev.candidateTracks_);
-    if(Config::removeDuplicates) builder.find_duplicates(ev.candidateTracks_);
+    //Mark tracks as duplicates; if within CMSSW, remove duplicate tracks before backward fit
+    if(Config::removeDuplicates) 
+    {
+      builder.find_duplicates(ev.candidateTracks_);
+      if(Config::cmssw_export) builder.remove_duplicates(ev.candidateTracks_);
+    }
   }
 
   // now do backwards fit... do we want to time this section?

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -183,6 +183,16 @@ double runBuildingTestPlexBestHit(Event& ev, MkBuilder& builder)
   __SSC_MARK(0x222);  // use this to pause Intel SDE at the same point
 #endif
 
+  if (Config::quality_val || Config::sim_val || Config::cmssw_val || Config::cmssw_export)
+  {
+    //Mark tracks as duplicates; if within CMSSW, remove duplicate tracks before backward fit   
+    if(Config::removeDuplicates)
+    {
+      builder.find_duplicates(ev.candidateTracks_);
+      if(Config::cmssw_export) builder.remove_duplicates(ev.candidateTracks_);
+    }
+  }
+
   // now do backwards fit... do we want to time this section?
   if (Config::backwardFit)
   {
@@ -342,7 +352,12 @@ double runBuildingTestPlexCloneEngine(Event& ev, MkBuilder& builder)
   if (Config::quality_val || Config::sim_val || Config::cmssw_val || Config::cmssw_export)
   {
     builder.quality_store_tracks(ev.candidateTracks_);
-    if(Config::removeDuplicates) builder.find_duplicates(ev.candidateTracks_);
+    //Mark tracks as duplicates; if within CMSSW, remove duplicate tracks before backward fit
+    if(Config::removeDuplicates)
+    {
+      builder.find_duplicates(ev.candidateTracks_);
+      if(Config::cmssw_export) builder.remove_duplicates(ev.candidateTracks_);
+    }
   }
 
   // now do backwards fit... do we want to time this section?
@@ -405,6 +420,12 @@ double runBuildingTestPlexFV(Event& ev, MkBuilder& builder)
   if (Config::quality_val || Config::sim_val || Config::cmssw_val || Config::cmssw_export)
   {
     builder.quality_store_tracks(ev.candidateTracks_);
+    //Mark tracks as duplicates; if within CMSSW, remove duplicate tracks before backward fit  
+    if(Config::removeDuplicates)
+    {
+      builder.find_duplicates(ev.candidateTracks_);
+      if(Config::cmssw_export) builder.remove_duplicates(ev.candidateTracks_);
+    }
   }
 
   // now do backwards fit... do we want to time this section?

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -183,6 +183,7 @@ double runBuildingTestPlexBestHit(Event& ev, MkBuilder& builder)
   __SSC_MARK(0x222);  // use this to pause Intel SDE at the same point
 #endif
 
+  //For best hit, the candidateTracks_ vector is the direct input to the backward fit so only need to do find_duplicates once
   if (Config::quality_val || Config::sim_val || Config::cmssw_val || Config::cmssw_export)
   {
     //Mark tracks as duplicates; if within CMSSW, remove duplicate tracks before backward fit   

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -646,8 +646,8 @@ int main(int argc, const char *argv[])
         "  --cf-seeding             enable conformal fit over seeds (def: %s)\n"
         "\n"
 	" **Duplicate removal options\n"
-	"  --remove-dup            run duplicate removal after building, using both hit and kinematic criteria"
-	"  --remove-dup-no-hit     run duplicate removal after building, using kinematic criteria only"
+	"  --remove-dup            run duplicate removal after building, using both hit and kinematic criteria (def: %s)\n"
+	"  --remove-dup-no-hit     run duplicate removal after building, using kinematic criteria only (def: %s)\n"
 	"\n"
 	" **Additional options for building\n"
         "  --chi2cut        <flt>   chi2 cut used in building test (def: %.1f)\n"
@@ -756,6 +756,9 @@ int main(int argc, const char *argv[])
 	getOpt(Config::seedInput, g_seed_opts).c_str(),
 	getOpt(Config::seedCleaning, g_clean_opts).c_str(),
         b2a(Config::cf_seeding),
+
+	b2a(Config::removeDuplicates && Config::useHitsForDuplicates),
+	b2a(Config::removeDuplicates && !Config::useHitsForDuplicates),
 
 	Config::chi2Cut,
 	b2a(Config::usePhiQArrays),

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -644,6 +644,10 @@ int main(int argc, const char *argv[])
         "  --seed-input     <str>   which seed collecion used for building (def: %s)\n"
         "  --seed-cleaning  <str>   which seed cleaning to apply if using cmssw seeds (def: %s)\n" 
         "  --cf-seeding             enable conformal fit over seeds (def: %s)\n"
+        "\n"
+	" **Duplicate removal options\n"
+	"  --remove-dup            run duplicate removal after building, using both hit and kinematic criteria"
+	"  --remove-dup-no-hit     run duplicate removal after building, using kinematic criteria only"
 	"\n"
 	" **Additional options for building\n"
         "  --chi2cut        <flt>   chi2 cut used in building test (def: %.1f)\n"
@@ -947,6 +951,16 @@ int main(int argc, const char *argv[])
 #else
       printf("--use-phiq-arr has no effect: recompile with CONFIG_PhiQArrays\n");
 #endif
+    }
+    else if(*i == "--remove-dup")
+    {
+      Config::removeDuplicates = true;
+      Config::useHitsForDuplicates = true;
+    }
+    else if(*i == "--remove-dup-no-hit")
+    {
+      Config::removeDuplicates = true;
+      Config::useHitsForDuplicates = false;
     }
     else if(*i == "--kludge-cms-hit-errors")
     {

--- a/val_scripts/validation-cmssw-benchmarks.sh
+++ b/val_scripts/validation-cmssw-benchmarks.sh
@@ -25,7 +25,7 @@ maxth=64
 maxvu=16
 maxev=32
 seeds="--cmssw-n2seeds"
-exe="./mkFit/mkFit --silent ${seeds} --num-thr ${maxth} --num-thr-ev ${maxev} --input-file ${dir}/${subdir}/${file} --num-events ${nevents}"
+exe="./mkFit/mkFit --silent ${seeds} --num-thr ${maxth} --num-thr-ev ${maxev} --input-file ${dir}/${subdir}/${file} --num-events ${nevents} --remove-dup"
 
 ## Common output setup
 tmpdir="tmp"

--- a/validation-desc.txt
+++ b/validation-desc.txt
@@ -182,7 +182,8 @@ The following routines are then called after the building (MkBuilder.cc, Event.c
   // Config::nMinFoundHits = 7, Config::nlayers_per_seed = 4 or 3 
   // nCandHits = trk.nFoundHits() OR trk.nFoundHits()-Config::nlayers_per_seed (see calling function)
   // nMinHits = Config::nMinFoundHits OR Config::nMinFoundHits-Config::nlayers_per_seed (see calling function)
-  : if (mc/cmsswTrackID >= 0) (i.e. the track has successfully matched)
+  : if track has been marked as a duplicate, mc/cmsswTrackID = -10
+  : else if (mc/cmsswTrackID >= 0) (i.e. the track has successfully matched)
     : if mc/cmsswTrack is findable
       : if nCandHits < nMinHits, mc/cmsswTrackID = -2
     : else
@@ -365,6 +366,7 @@ Fake Rate (with only long reco tracks: Config::inclusiveShorts == false) [PlotVa
   mcTrackID | mcmask_[reco] 
      >= 0   |     1
     -1,-9   |     0
+     -10    |     2
      else   |    -1 // OR the seed track does produce a build/fit track as determined by the seedToBuild/FitMap
 
 Fake Rate (with all reco tracks: Config::inclusiveShorts == true, enabled with command line option: --inc-shorts) [PlotValidation::PlotFakeRate()]
@@ -373,7 +375,7 @@ Fake Rate (with all reco tracks: Config::inclusiveShorts == true, enabled with c
   mcTrackID  | mcmask_[reco] 
     >= 0     |     1
  -1,-5,-8,-9 |     0
-     -2      |     2   
+   -2,-10    |     2   
     else     |    -1 // OR the seed track does produce a build/fit track as determined by the seedToBuild/FitMap
 
 Duplicate Rate [PlotValidation::PlotDuplicateRate()], see special note in section H

--- a/validation-desc.txt
+++ b/validation-desc.txt
@@ -366,7 +366,7 @@ Fake Rate (with only long reco tracks: Config::inclusiveShorts == false) [PlotVa
   mcTrackID | mcmask_[reco] 
      >= 0   |     1
     -1,-9   |     0
-     -10    |     2
+     -10    |    -2
      else   |    -1 // OR the seed track does produce a build/fit track as determined by the seedToBuild/FitMap
 
 N.B. In the MTV-Like SimVal: the requirement on minHits is removed, so all reco tracks are considered.
@@ -380,7 +380,8 @@ Fake Rate (with all reco tracks: Config::inclusiveShorts == true, enabled with c
   mcTrackID  | mcmask_[reco] 
     >= 0     |     1
  -1,-5,-8,-9 |     0
-   -2,-10    |     2   
+    -10      |    -2
+     -2      |     2   
     else     |    -1 // OR the seed track does produce a build/fit track as determined by the seedToBuild/FitMap
 
 Duplicate Rate [PlotValidation::PlotDuplicateRate()], see special note in section H


### PR DESCRIPTION
First pass at duplicate removal. Current algorithm is to remove the track with the lower score in a pair of tracks satisfying:
fracHitsShared > 0.75, delta phi < 0.1, std::abs(pt2 - pt1)/maxpt < 0.05 and delta eta < 0.2

This can be re-optimized after we fix the efficiency for short tracks.

Plots can be found here. This includes plots with and without duplicate removal, with and without the mtv-like-val option, and plots comparing the performance within CMSSW:
http://areinsvo.web.cern.ch/areinsvo/MkFit/DuplicateRemoval/forPR/

I haven’t tried to optimize it for timing yet; I wanted to get the physics results out to include in my Connecting the Dots presentation.