### PR TITLE
Explore not storing/copying the sorted hits and hit prefetching.

### DIFF
--- a/mkFit/Ice/IceRevisitedRadix.cc
+++ b/mkFit/Ice/IceRevisitedRadix.cc
@@ -202,6 +202,22 @@ RadixSort::~RadixSort()
 
 //----------------------------------------------------------------------
 /**
+ * Detach mRanks. After this the caller is responsible for
+ * freeing this array via delete [] operator.
+ */
+//----------------------------------------------------------------------
+udword* RadixSort::RelinquishRanks()
+{
+  udword *ranks = mRanks;
+  mRanks = 0;
+  DELETEARRAY(mRanks2);
+  mCurrentSize = 0;
+  return ranks;
+}
+
+
+//----------------------------------------------------------------------
+/**
  *	Resizes the inner lists.
  *	\param		nb	[in] new size (number of dwords)
  *	\return		true if success

--- a/mkFit/Ice/IceRevisitedRadix.h
+++ b/mkFit/Ice/IceRevisitedRadix.h
@@ -40,6 +40,10 @@ public:
   //i.e. in the order you may further process your data
   const udword*	GetRanks() const { return mRanks; }
 
+  //! Detach mRanks. After this the caller is responsible for
+  //! freeing this array via delete [] operator.
+  udword* RelinquishRanks();
+
   //! mIndices2 gets trashed on calling the sort routine, but
   //otherwise you can recycle it the way you want.
   udword* GetRecyclable() const { return mRanks2; }

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -611,9 +611,10 @@ void MkBuilder::find_seeds()
   // XXMT4K  ... configurable input layers ... or hardcode something else for endcap.
   // Could come from TrackerInfo ...
   // But what about transition ... TrackerInfo as well or arbitrary combination of B/E seed layers ????
-  const Hit * lay0hits = m_event_of_hits.m_layers_of_hits[0].m_hits;
-  const Hit * lay1hits = m_event_of_hits.m_layers_of_hits[1].m_hits;
-  const Hit * lay2hits = m_event_of_hits.m_layers_of_hits[2].m_hits;
+
+  const LayerOfHits &loh0 = m_event_of_hits.m_layers_of_hits[0];
+  const LayerOfHits &loh1 = m_event_of_hits.m_layers_of_hits[1];
+  const LayerOfHits &loh2 = m_event_of_hits.m_layers_of_hits[2];
 
   // make seed tracks
   TrackVec & seedtracks = m_event->seedTracks_;
@@ -624,9 +625,9 @@ void MkBuilder::find_seeds()
     seedtrack.setLabel(iseed);
 
     // use to set charge
-    const Hit & hit0 = lay0hits[seed_idcs[iseed][0]];
-    const Hit & hit1 = lay1hits[seed_idcs[iseed][1]];
-    const Hit & hit2 = lay2hits[seed_idcs[iseed][2]];
+    const Hit & hit0 = loh0.GetHit(seed_idcs[iseed][0]);
+    const Hit & hit1 = loh1.GetHit(seed_idcs[iseed][1]);
+    const Hit & hit2 = loh2.GetHit(seed_idcs[iseed][2]);
 
     seedtrack.setCharge(calculateCharge(hit0,hit1,hit2));
 
@@ -816,12 +817,12 @@ void MkBuilder::map_track_hits(TrackVec & tracks)
   {
     if (layer_has_hits[ilayer])
     {
-      const auto & lof_m_hits = m_event_of_hits.m_layers_of_hits[ilayer].m_hits;
+      const auto  &loh  = m_event_of_hits.m_layers_of_hits[ilayer];
       const auto   size = m_event->layerHits_[ilayer].size();
 
       for (size_t index = 0; index < size; ++index)
       {
-        const auto mcHitID = lof_m_hits[index].mcHitID();
+        const auto mcHitID = loh.GetHit(index).mcHitID();
         min = std::min(min, mcHitID);
         max = std::max(max, mcHitID);
       }
@@ -834,12 +835,12 @@ void MkBuilder::map_track_hits(TrackVec & tracks)
   {
     if (layer_has_hits[ilayer])
     {
-      const auto & lof_m_hits = m_event_of_hits.m_layers_of_hits[ilayer].m_hits;
+      const auto  &loh  = m_event_of_hits.m_layers_of_hits[ilayer];
       const auto   size = m_event->layerHits_[ilayer].size();
 
       for (size_t index = 0; index < size; ++index)
       {
-        trackHitMap[lof_m_hits[index].mcHitID()-min] = index;
+        trackHitMap[loh.GetHit(index).mcHitID()-min] = index;
       }
     }
   }
@@ -902,8 +903,8 @@ void MkBuilder::remap_track_hits(TrackVec & tracks)
       int hitlyr = track.getHitLyr(i);
       if (hitidx >= 0)
       {
-        const auto & lof_m_hits = m_event_of_hits.m_layers_of_hits[hitlyr].m_hits;
-        track.setHitIdx(i, trackHitMap[lof_m_hits[hitidx].mcHitID()-min]);
+        const auto & loh = m_event_of_hits.m_layers_of_hits[hitlyr];
+        track.setHitIdx(i, trackHitMap[loh.GetHit(hitidx).mcHitID() - min]);
       }
     }
   }

--- a/mkFit/MkFitter.cc
+++ b/mkFit/MkFitter.cc
@@ -150,7 +150,7 @@ void MkFitter::InputTracksAndHits(const std::vector<Track>&  tracks,
     {
       const int hidx = trk.getHitIdx(hi);
       const int hlyr = trk.getHitLyr(hi);
-      const Hit &hit = layerHits[hlyr].m_hits[hidx];
+      const Hit &hit = layerHits[hlyr].GetHit(hidx);
 
       msErr[hi].CopyIn(itrack, hit.errArray());
       msPar[hi].CopyIn(itrack, hit.posArray());

--- a/mkFit/mt-notes.txt
+++ b/mkFit/mt-notes.txt
@@ -1,3 +1,128 @@
+Using non-sorted hits from external hit-vector ...
+----------------------------------------------
+
+... and keeping hit ranks for access.
+
+*** Summary:
+
+- Not sorting hits does not hurt performance, very little change.
+
+  TO DECIDE: Do we keep both options with ifdefs?
+
+- Test performance without doing the explicit mm_prefetch.
+
+  ifdefs were there (MkFinder) for best-hit, I added them for clone engine
+  and for standard. Did not do it for FV yet.
+
+  It seems there is no benefit from prefetchin at all, even when
+  hits are not copied into sorted order!
+  In fact, about 3% faster.
+  [It made me think hits are alrady sorted ... well, they seem to be within
+  a module ... but the direction is not necessarily the same.]
+
+  TO DECIDE: Do we remove prefetching instructions or we just
+  ifdef them out by default.
+
+- Fix in quality_val where we search for the seed track which was wrong due
+  to seed cleaning. Kevin, please review.
+
+  Note that with ranks (and reverse ranks) we could do hit index remapping
+  without building of translation maps.
+  Kevin and I (tohether) can probably do it rather fast.
+
+
+*** Funny crash:
+
+SEGV in mm_prefetch when preloading a hit.
+
+Seems to only happen with O3, nun-thr >= 4, prefetching on (obviously).
+
+I'm tracing it down as it really shouldn't happen. Seems more like an icc bug.
+
+
+*** "Physics performance" test
+
+Compare quality-val output on first 5 events.
+1. Expect no change.
+2. Observe some improvement with new code for some events ... probably due to fix in
+   getting the seed track.
+
+
+*** Timing tests: clone engine, single thread, pu70-ccc, 500 events
+
+time ./mkFit --cmssw-n2seeds --input-file ../../mictest/mkFit/pu70-ccc-hs.bin --build-ce --num-events 500
+
+- "Manual" prefetching that we have hurts a little.
+  Surprisingly, even when not storing sorted hits.
+
+= devel
+
+  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 69.67924  FVMX = 0.00000
+  Total event loop time 79.82160 simtracks 4943065 seedtracks 1040426 builtcands 3421025 maxhits 6117 on lay 5
+  real    1m19.853s  user    1m18.097s  sys     0m1.552s
+
+= hit-sort - no hit copy
+
+  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 69.85903  FVMX = 0.00000
+  Total event loop time 79.78304 simtracks 4943065 seedtracks 1040426 builtcands 3421025 maxhits 5998 on lay 5
+  real    1m19.819s  user    1m18.050s  sys     0m1.563s
+
+= hit-sort - no hit copy - AVX_512
+
+  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 46.86359  FVMX = 0.00000
+  Total event loop time 57.06883 simtracks 4943065 seedtracks 1040426 builtcands 3421071 maxhits 5998 on lay 5
+  real    0m57.099s  user    0m55.389s  sys     0m1.560s
+
+
+= hit-sort - no hit copy - no prefetch
+
+  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 67.40083  FVMX = 0.00000
+  Total event loop time 77.28962 simtracks 4943065 seedtracks 1040426 builtcands 3421025 maxhits 5998 on lay 5
+  real    1m17.319s  user    1m15.600s  sys     0m1.521s
+
+= hit-sort - no hit copy - no prefetch - AVX_512
+
+  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 44.65550  FVMX = 0.00000
+  Total event loop time 54.89823 simtracks 4943065 seedtracks 1040426 builtcands 3421071 maxhits 5998 on lay 5
+  real    0m54.925s  user    0m53.196s  sys     0m1.584s
+
+= hit-sort - no hit copy - no prefetch - AVX2
+
+  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 53.88735  FVMX = 0.00000
+  Total event loop time 63.83459 simtracks 4943065 seedtracks 1040426 builtcands 3421022 maxhits 5998 on lay 5
+  real    1m3.861s  user    1m2.114s  sys     0m1.578s
+
+= hit-sort - yes hit copy
+
+  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 69.97530  FVMX = 0.00000
+  Total event loop time 80.25051 simtracks 4943065 seedtracks 1040426 builtcands 3421025 maxhits 5998 on lay 5
+  real    1m20.279s  user    1m18.494s  sys     0m1.579s
+
+= hit-sort - yes hit copy - no prefetch
+
+  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 66.97209  FVMX = 0.00000
+  Total event loop time 77.29263 simtracks 4943065 seedtracks 1040426 builtcands 3421025 maxhits 5998 on lay 5
+  real    1m17.322s  user    1m15.508s  sys     0m1.615s
+
+
+*** Timing tests: clone engine, 64 threads / 16 in flight, pu70-ccc, avx-512, 5000 events:
+
+time ./mkFit --cmssw-n2seeds --input-file ../../mictest/mkFit/pu70-ccc-hs.bin --build-ce --num-events 5000 --num-thr 64 --num-thr-ev 16
+
+= devel
+
+  Total event loop time 17.07450 simtracks 49338285 seedtracks 10275105 builtcands 33905375 maxhits 6473 on lay 5
+  real    0m17.211s  user    16m14.243s  sys     0m33.480s
+
+= hit-sort - no hit copy - no prefetch
+
+  Total event loop time 16.56905 simtracks 49338285 seedtracks 10275105 builtcands 33905375 maxhits 6347 on lay 5
+  real    0m16.692s  user    15m51.343s  sys     0m31.998s
+
+
+
+================================================================================
+
 Barrel, maxHolesPerCand=3 losses
 --------------------------------
 
@@ -41,6 +166,8 @@ diff -u fce-nh-12.txt fce-nh-3.txt
     hit 12 lyr=16 idx=  0 pos r= 94.623 x=  80.155 y=  50.286 z=  -9.231   mc_hit=225 mc_trk=  5
     hit 13 lyr=17 idx=  0 pos r=106.803 x=  89.843 y=  57.750 z=  -9.230   mc_hit=236 mc_trk=  5
 
+
+================================================================================
 
 Tracing down silly values in track errors
 -----------------------------------------

--- a/mkFit/seedtestMPlex.cc
+++ b/mkFit/seedtestMPlex.cc
@@ -44,7 +44,7 @@ void findSeedsByRoadSearch(TripletIdxConVec & seed_idcs, std::vector<LayerOfHits
       TripletIdxVec temp_thr_seed_idcs;		      
       for (int ihit1 = i.begin(); ihit1 < i.end(); ++ihit1)
       {
-	const Hit & hit1   = lay1_hits.m_hits[ihit1];
+	const Hit & hit1   = lay1_hits.GetHit(ihit1);
 	const float hit1_z = hit1.z();
 			     
 	dprint("ihit1: " << ihit1 << " mcTrackID: " << hit1.mcTrackID(ev->simHitsInfo_) << " phi: " << hit1.phi() << " z: " << hit1.z());
@@ -55,7 +55,7 @@ void findSeedsByRoadSearch(TripletIdxConVec & seed_idcs, std::vector<LayerOfHits
 	// loop over first layer hits
 	for (auto&& ihit0 : cand_hit0_indices)
 	{
-	  const Hit & hit0   = lay0_hits.m_hits[ihit0]; 
+	  const Hit & hit0   = lay0_hits.GetHit(ihit0);
 	  const float hit0_z = hit0.z();
 	  const float hit0_x = hit0.x(); const float hit0_y = hit0.y();
 	  const float hit1_x = hit1.x(); const float hit1_y = hit1.y();
@@ -95,7 +95,7 @@ void findSeedsByRoadSearch(TripletIdxConVec & seed_idcs, std::vector<LayerOfHits
 	  for (size_t idx = 0; idx < cand_hit2_indices.size(); ++idx)
 	  {
             const int ihit2 = cand_hit2_indices[idx];
-	    const Hit & hit2 = lay2_hits.m_hits[ihit2];
+	    const Hit & hit2 = lay2_hits.GetHit(ihit2);
 
 	    const float lay1_predz = (hit0_z + hit2.z()) / 2.0f;
 	    // filter by residual of second layer hit


### PR DESCRIPTION
Using non-sorted hits from external hit-vector and keeping hit ranks for access.
----------------------------------------------------------------------------------------------------

*** Summary:

- Not sorting hits does not hurt performance, very little change.
  TO DECIDE: Do we keep both options with ifdefs?

- Test performance without doing the explicit mm_prefetch.
  ifdefs were there (MkFinder) for best-hit, I added them for clone engine
  and for standard. Did not do it for FV yet.

  It seems there is no benefit from prefetchin at all, even when
  hits are not copied into sorted order!
  In fact, about 3% faster.
  [It made me think hits are alrady sorted ... well, they seem to be within
  a module ... but the direction is not necessarily the same.]

  TO DECIDE: Do we remove prefetching instructions or we just ifdef them out by default.

- Fix in quality_val where we search for the seed track which was wrong due
  to seed cleaning. Kevin, please review.

  Note that with ranks (and reverse ranks) we could do hit index remapping
  without building of translation maps.
  Kevin and I (tohether) can probably do it rather fast.

*** Funny crash:

SEGV in mm_prefetch when preloading a hit.

Seems to only happen with O3, nun-thr >= 4, prefetching on (obviously).

I'm tracing it down as it really shouldn't happen. Seems more like an icc bug.


*** "Physics performance" test

Compare quality-val output on first 5 events.
1. Expect no change.
2. Observe some improvement with new code for some events ... probably due to fix in
   getting the seed track.


*** Timing tests: clone engine, single thread, pu70-ccc, 500 events

time ./mkFit --cmssw-n2seeds --input-file ../../mictest/mkFit/pu70-ccc-hs.bin --build-ce --num-events 500

- "Manual" prefetching that we have hurts a little.
  Surprisingly, even when not storing sorted hits.

= devel

  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 69.67924  FVMX = 0.00000
  Total event loop time 79.82160 simtracks 4943065 seedtracks 1040426 builtcands 3421025 maxhits 6117 on lay 5
  real    1m19.853s  user    1m18.097s  sys     0m1.552s

= hit-sort - no hit copy

  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 69.85903  FVMX = 0.00000
  Total event loop time 79.78304 simtracks 4943065 seedtracks 1040426 builtcands 3421025 maxhits 5998 on lay 5
  real    1m19.819s  user    1m18.050s  sys     0m1.563s

= hit-sort - no hit copy - AVX_512

  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 46.86359  FVMX = 0.00000
  Total event loop time 57.06883 simtracks 4943065 seedtracks 1040426 builtcands 3421071 maxhits 5998 on lay 5
  real    0m57.099s  user    0m55.389s  sys     0m1.560s


= hit-sort - no hit copy - no prefetch

  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 67.40083  FVMX = 0.00000
  Total event loop time 77.28962 simtracks 4943065 seedtracks 1040426 builtcands 3421025 maxhits 5998 on lay 5
  real    1m17.319s  user    1m15.600s  sys     0m1.521s

= hit-sort - no hit copy - no prefetch - AVX_512

  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 44.65550  FVMX = 0.00000
  Total event loop time 54.89823 simtracks 4943065 seedtracks 1040426 builtcands 3421071 maxhits 5998 on lay 5
  real    0m54.925s  user    0m53.196s  sys     0m1.584s

= hit-sort - no hit copy - no prefetch - AVX2

  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 53.88735  FVMX = 0.00000
  Total event loop time 63.83459 simtracks 4943065 seedtracks 1040426 builtcands 3421022 maxhits 5998 on lay 5
  real    1m3.861s  user    1m2.114s  sys     0m1.578s

= hit-sort - yes hit copy

  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 69.97530  FVMX = 0.00000
  Total event loop time 80.25051 simtracks 4943065 seedtracks 1040426 builtcands 3421025 maxhits 5998 on lay 5
  real    1m20.279s  user    1m18.494s  sys     0m1.579s

= hit-sort - yes hit copy - no prefetch

  Total Matriplex fit = 0.00000  --- Build  BHMX = 0.00000  STDMX = 0.00000  CEMX = 66.97209  FVMX = 0.00000
  Total event loop time 77.29263 simtracks 4943065 seedtracks 1040426 builtcands 3421025 maxhits 5998 on lay 5
  real    1m17.322s  user    1m15.508s  sys     0m1.615s


*** Timing tests: clone engine, 64 threads / 16 in flight, pu70-ccc, avx-512, 5000 events:

time ./mkFit --cmssw-n2seeds --input-file ../../mictest/mkFit/pu70-ccc-hs.bin --build-ce --num-events 5000 --num-thr 64 --num-thr-ev 16

= devel

  Total event loop time 17.07450 simtracks 49338285 seedtracks 10275105 builtcands 33905375 maxhits 6473 on lay 5
  real    0m17.211s  user    16m14.243s  sys     0m33.480s

= hit-sort - no hit copy - no prefetch

  Total event loop time 16.56905 simtracks 49338285 seedtracks 10275105 builtcands 33905375 maxhits 6347 on lay 5
  real    0m16.692s  user    15m51.343s  sys     0m31.998s
