### PR TITLE
Updating score, maxHoles and chi2Cut

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -357,8 +357,8 @@ namespace Config
   constexpr float track_ptlow = 0.9;
 
   // sorting config (bonus,penalty)
-  constexpr float validHitBonus_ = 2.5;
-  constexpr float missingHitPenalty_ = 20.0;
+  constexpr float validHitBonus_ = 10.0;//2.5*4.0;
+  constexpr float missingHitPenalty_ = 5.0;//20.0/4.0;
   constexpr float maxChi2ForRanking_ = 819.2f; // (=0.5f*0.1f*pow(2,14);)
 
   // Threading

--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -18,8 +18,10 @@ namespace
     Config::useCMSGeom       = true;
     Config::nlayers_per_seed = 4;
     Config::maxCandsPerSeed  = 6;  // GC said 3 is enough ???
-    Config::maxHolesPerCand  = 12; // should be reduced
-    Config::chi2Cut          = 30.0;
+    Config::maxHolesPerCand  = 3; // should be reduced
+    Config::chi2Cut          = 15.0;
+//    Config::maxHolesPerCand  = 12; // should be reduced
+//    Config::chi2Cut          = 30.0;
 
     Config::finding_requires_propagation_to_hit_pos = true;
     Config::finding_inter_layer_pflags = PropagationFlags(PF_apply_material);

--- a/Track.h
+++ b/Track.h
@@ -551,23 +551,43 @@ inline int getScoreCalc(const unsigned int seedtype,
   //if(chi2>Config::maxChi2ForRanking_) chi2=Config::maxChi2ForRanking_;
   int score = 0;
   float score_ = 0.f;
+//  // For high pT central tracks: double valid hit bonus
+//  if(seedtype==1){
+//    score_ = (Config::validHitBonus_*2.0f)*nfoundhits - Config::missingHitPenalty_*nmisshits - chi2;
+//    if(pt<0.9f) score_ -= 0.5f*(Config::validHitBonus_*2.0f)*nfoundhits;
+//    else if(nfoundhits>8) score_ += (Config::validHitBonus_*2.0f)*nfoundhits;
+//  }
+//  // For low pT endcap tracks: half valid hit bonus & half missing hit penalty
+//  else if(seedtype==2){
+//    score_ = (Config::validHitBonus_*0.5f)*nfoundhits - (Config::missingHitPenalty_*0.5f)*nmisshits - chi2;
+//    if(pt<0.9f) score_ -= 0.5f*(Config::validHitBonus_*0.5f)*nfoundhits;
+//    else if(nfoundhits>8) score_ += (Config::validHitBonus_*0.5f)*nfoundhits;
+//  }
+//  // For all other tracks: unchanged cmssw bonus and penalty
+//  else{
+//    score_ = Config::validHitBonus_*nfoundhits - Config::missingHitPenalty_*nmisshits - chi2;
+//    if(pt<0.9f) score_ -= 0.5f*Config::validHitBonus_*nfoundhits;
+//    else if(nfoundhits>8) score_ += Config::validHitBonus_*nfoundhits;
+////    if(pt<0.9f) score_ -= 0.25f*Config::validHitBonus_*nfoundhits;
+////    if(nfoundhits>8) score_ += Config::validHitBonus_*nfoundhits;
+//  }
   // For high pT central tracks: double valid hit bonus
   if(seedtype==1){
-    score_ = (Config::validHitBonus_*2.0f)*nfoundhits - Config::missingHitPenalty_*nmisshits - chi2;
-    if(pt<0.9f) score_ -= 0.5f*(Config::validHitBonus_*2.0f)*nfoundhits;
-    else if(nfoundhits>8) score_ += (Config::validHitBonus_*2.0f)*nfoundhits;
+    score_ = (Config::validHitBonus_*4.0f)*nfoundhits - Config::missingHitPenalty_*nmisshits*0.25f - chi2;
+    if(pt<0.9f) score_ -= 0.25f*(Config::validHitBonus_)*nfoundhits;
+    if(nfoundhits>8) score_ += (Config::validHitBonus_*2.0f)*nfoundhits;
   }
   // For low pT endcap tracks: half valid hit bonus & half missing hit penalty
   else if(seedtype==2){
-    score_ = (Config::validHitBonus_*0.5f)*nfoundhits - (Config::missingHitPenalty_*0.5f)*nmisshits - chi2;
-    if(pt<0.9f) score_ -= 0.5f*(Config::validHitBonus_*0.5f)*nfoundhits;
-    else if(nfoundhits>8) score_ += (Config::validHitBonus_*0.5f)*nfoundhits;
+    score_ = (Config::validHitBonus_*2.0f)*nfoundhits - Config::missingHitPenalty_*nmisshits*0.25f - chi2;
+    if(pt<0.9f) score_ -= 0.25f*(Config::validHitBonus_*0.5f)*nfoundhits;
+    if(nfoundhits>8) score_ += (Config::validHitBonus_*1.0f)*nfoundhits;
   }
   // For all other tracks: unchanged cmssw bonus and penalty
   else{
-    score_ = Config::validHitBonus_*nfoundhits - Config::missingHitPenalty_*nmisshits - chi2;
-    if(pt<0.9f) score_ -= 0.5f*Config::validHitBonus_*nfoundhits;
-    else if(nfoundhits>8) score_ += Config::validHitBonus_*nfoundhits;
+    score_ = (Config::validHitBonus_*4.0f)*nfoundhits - Config::missingHitPenalty_*nmisshits - chi2;
+    if(pt<0.9f) score_ -= 0.2f*(Config::validHitBonus_)*nfoundhits;
+    if(nfoundhits>8) score_ += (Config::validHitBonus_)*nfoundhits;
   }
   score = (int)(floor(10.f * score_ + 0.5));
   return score;


### PR DESCRIPTION
Updating candidate score calculation on top of Matevz's fix for counting of missing hits.
This reflects physics performance shown at CMS week (April 2019, Tracking POG).