### PR TITLE
Minor improvements to SelectHitIndices

### DIFF
--- a/mkFit/HitStructures.cc
+++ b/mkFit/HitStructures.cc
@@ -29,7 +29,6 @@ void LayerOfHits::setup_bins(float qmin, float qmax, float dq)
   m_fq = m_nq / (qmax - qmin); // qbin = (q_hit - m_qmin) * m_fq;
 
   m_phi_bin_infos.resize(m_nq);
-  for (int i = 0; i < m_nq; ++i) m_phi_bin_infos[i].resize(Config::m_nphi);
 }
 
 void LayerOfHits::SetupLayer(const LayerInfo &li)

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -38,7 +38,7 @@ typedef tbb::concurrent_vector<TripletIdx> TripletIdxConVec;
 
 typedef std::pair<uint16_t, uint16_t> PhiBinInfo_t;
 
-typedef std::vector<PhiBinInfo_t> vecPhiBinInfo_t;
+typedef std::array<PhiBinInfo_t, Config::m_nphi> vecPhiBinInfo_t;
 
 typedef std::vector<vecPhiBinInfo_t> vecvecPhiBinInfo_t;
 

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -391,10 +391,7 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
             // Avi says we should have *minimal* search windows per layer.
             // Also ... if bins are sufficiently small, we do not need the extra
             // checks, see above.
-            // if (ddq < dq && ddphi < dphi)
-            // {
-              XHitArr.At(itrack, XHitSize[itrack]++, 0) = hi;
-            // }
+	    XHitArr.At(itrack, XHitSize[itrack]++, 0) = hi;
 	  }
 	  else
 	  {

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -374,25 +374,27 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
 
 	  if (Config::usePhiQArrays)
 	  {
-            if (XHitSize[itrack] >= MPlexHitIdxMax) continue;
+            if (XHitSize[itrack] >= MPlexHitIdxMax) break;
 
             const float ddq   =       std::abs(q   - L.m_hit_qs[hi]);
+            if (ddq >= dq) continue;
             const float ddphi = cdist(std::abs(phi - L.m_hit_phis[hi]));
+            if (ddphi >= dphi) continue;
             
-            dprintf("     SHI %3d %4d %4d %5d  %6.3f %6.3f %6.4f %7.5f   %s\n",
-                    qi, pi, pb, hi,
-                    L.m_hit_qs[hi], L.m_hit_phis[hi], ddq, ddphi,
-                    (ddq < dq && ddphi < dphi) ? "PASS" : "FAIL");
+            // dprintf("     SHI %3d %4d %4d %5d  %6.3f %6.3f %6.4f %7.5f   %s\n",
+            //         qi, pi, pb, hi,
+            //         L.m_hit_qs[hi], L.m_hit_phis[hi], ddq, ddphi,
+            //         (ddq < dq && ddphi < dphi) ? "PASS" : "FAIL");
             
             // MT: Removing extra check gives full efficiency ...
             //     and means our error estimations are wrong!
             // Avi says we should have *minimal* search windows per layer.
             // Also ... if bins are sufficiently small, we do not need the extra
             // checks, see above.
-            if (ddq < dq && ddphi < dphi)
-            {
+            // if (ddq < dq && ddphi < dphi)
+            // {
               XHitArr.At(itrack, XHitSize[itrack]++, 0) = hi;
-            }
+            // }
 	  }
 	  else
 	  {


### PR DESCRIPTION
After playing a couple of days with SelectHitIndices, found no way to improve the memory flow with the current data structures. A couple of minor changes give a percent-level speedup.

Benchmarks:
https://cerati.web.cern.ch/cerati/test-shi-v7

To be compared with:
https://mmasciov.web.cern.ch/mmasciov/benchmark_short-track-stash_BHscore

In particular the small speedup is visible here:
https://cerati.web.cern.ch/cerati/test-shi-v7/Benchmarks/SKL-SP_CMSSW_TTbar_PU70_VU_time.png
https://mmasciov.web.cern.ch/mmasciov/benchmark_short-track-stash_BHscore/Benchmarks/SKL-SP_CMSSW_TTbar_PU70_VU_time.png
