### PR TITLE
drop KNL mention re "about 10 faster" in CHEP18

### DIFF
--- a/paper/pkf-chep2018-tadel.tex
+++ b/paper/pkf-chep2018-tadel.tex
@@ -548,10 +548,8 @@ estimate with the current version of code which we believe can be further
 optimized. A significant increase in speed could also be achieved by not
 processing the seeds with estimated $p_T$ below certain threshold.
 
-{ADD/CHANGE Rewrite the following paragraph with Skylake results?}
-
 Comparing CMSSW and \mkfit single-threaded performance of initial iteration tracking
-on KNL one finds that \mkfit runs about 10-times faster than CMSSW tracking.
+one finds that \mkfit runs about 10-times faster than CMSSW tracking.
 While this indicates \mkfit brings
 significant improvements in processing rates, this result should be deemed
 preliminary, especially since track post-processing has not yet been


### PR DESCRIPTION
"about 10" is broad enough to cover the range of values we measured with a later version of our code compared on SKL.
My Jan 18 slides have x11 with AVX512 turbo on and x8 with "core2".


