### PR TITLE
safer delete

### DIFF
--- a/mkFit/HitStructures.cc
+++ b/mkFit/HitStructures.cc
@@ -151,7 +151,7 @@ void LayerOfHits::SuckInHits(const HitVec &hitv)
   }
 
 #ifndef COPY_SORTED_HITS
-  delete [] m_hit_ranks;
+  operator delete [] (m_hit_ranks);
   m_hit_ranks = sort.RelinquishRanks();
   m_ext_hits  = & hitv;
 #endif

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -196,7 +196,7 @@ public:
 #ifdef COPY_SORTED_HITS
     free_hits();
 #else
-    delete [] m_hit_ranks;
+    operator delete [] (m_hit_ranks);
 #endif
   }
 


### PR DESCRIPTION
```delete [] x ``` -> ```operator delete [] (x)```
to avoid locks in jemalloc.

This came up in tests with CMSSW.
