### PR TITLE
Add val option for mtv requiring sim tracks matched to seeds

### DIFF
--- a/Config.cc
+++ b/Config.cc
@@ -93,6 +93,7 @@ namespace Config
   float minFracHitsShared = 0.75;
 
   bool mtvLikeValidation = false;
+  bool mtvRequireSeeds = false;
   int  cmsSelMinLayers = 12;
   int  nMinFoundHits = 10;
 

--- a/Config.h
+++ b/Config.h
@@ -305,6 +305,7 @@ namespace Config
   extern    int maxCandsPerEtaBin;
 
   extern    bool mtvLikeValidation;
+  extern    bool mtvRequireSeeds;
   // Selection of simtracks from CMSSW. Used in Event::clean_cms_simtracks() and MkBuilder::prep_cmsswtracks()
   extern    int   cmsSelMinLayers;
 

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -1174,16 +1174,6 @@ void MkBuilder::prep_simtracks()
   // First prep sim tracks to have hits sorted, then mark unfindable if too short
   prep_reftracks(m_event->simTracks_,m_event->simTracksExtra_,false);
 
-  if (Config::mtvLikeValidation) {
-    // Apply MTV selection criteria and then return
-    for (auto& simtrack : m_event->simTracks_)
-      {
-	if (simtrack.isNotFindable()) continue; // skip ones we already know are bad
-	if (simtrack.prodType()!=Track::ProdType::Signal || simtrack.charge()==0 || simtrack.posR()>3.5 || std::abs(simtrack.z())>30 || std::abs(simtrack.momEta())>2.5) simtrack.setNotFindable();
-      }
-    return;
-  }
-
   // Now, make sure sim track shares at least four hits with a single cmssw seed.
   // This ensures we factor out any weakness from CMSSW
 
@@ -1235,8 +1225,15 @@ void MkBuilder::prep_simtracks()
       }
     }
 
-    // set findability based on bool isSimSeed
-    if (!isSimSeed) simtrack.setNotFindable();
+    if (Config::mtvLikeValidation) {
+      // Apply MTV selection criteria and then return                                                                                                                                                                     
+      if (simtrack.prodType()!=Track::ProdType::Signal || simtrack.charge()==0 || simtrack.posR()>3.5 || std::abs(simtrack.z())>30 || std::abs(simtrack.momEta())>2.5) simtrack.setNotFindable();
+      else if(Config::mtvRequireSeeds && !isSimSeed) simtrack.setNotFindable();
+    }
+    else{
+      // set findability based on bool isSimSeed                                                                                                                                                                         
+      if (!isSimSeed) simtrack.setNotFindable();
+    }
   }
 
 }

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -663,6 +663,7 @@ int main(int argc, const char *argv[])
 	"                             must enable: --dump-for-plots\n"
 	"  --dump-for-plots         make shell printouts for plots (def: %s)\n"
         "  --mtv-like-val           configure validation to emulate CMSSW MultiTrackValidator (MTV) (def: %s)\n"
+	"  --mtv-require-seeds           configure validation to emulate MTV but require sim tracks to be matched to seeds (def: %s)\n"
 	"\n"
 	" **ROOT based options\n"
         "  --sim-val-for-cmssw      enable ROOT based validation for CMSSW tracks with simtracks as reference [eff, FR, DR] (def: %s)\n"
@@ -770,6 +771,7 @@ int main(int argc, const char *argv[])
         b2a(Config::quality_val),
         b2a(Config::dumpForPlots),
         b2a(Config::mtvLikeValidation),
+	b2a(Config::mtvRequireSeeds),
 
         b2a(Config::sim_val_for_cmssw),
         b2a(Config::sim_val),
@@ -995,6 +997,13 @@ int main(int argc, const char *argv[])
       Config::mtvLikeValidation = true;
       Config::cmsSelMinLayers = 0;
       Config::nMinFoundHits = 0;
+    }
+    else if (*i == "--mtv-require-seeds")
+    {
+	Config::mtvLikeValidation = true;
+	Config::cmsSelMinLayers = 0;
+	Config::nMinFoundHits = 0;
+	Config::mtvRequireSeeds = true;
     }
     else if (*i == "--sim-val-for-cmssw")
     {


### PR DESCRIPTION
Using --mtv-require-seeds, you can now get MTV-like validation but with the additional requirements that the sim tracks are matched to a seed. All of the benchmark and validation plots are here, including the SIMVAL for the extra option and the normal MTV-like validation.
http://areinsvo.web.cern.ch/areinsvo/MkFit/Benchmarks/July2019_AddValOpt/ 