### PR TITLE
Update score calc, add warning for score overflow

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -359,7 +359,7 @@ namespace Config
   constexpr float track_ptlow = 0.9;
 
   // sorting config (bonus,penalty)
-  constexpr float validHitBonus_ = 10.0;//2.5*4.0; // 4x cmssw bonus (after fix for counts of # missing hits)
+  constexpr float validHitBonus_ = 5.0;//2.5*4.0; // 4x cmssw bonus (after fix for counts of # missing hits)
   constexpr float missingHitPenalty_ = 5.0;//20.0/4.0; // 0.25x cmssw penalty (after fix for counts of # missing hits)  
   constexpr float maxChi2ForRanking_ = 819.2f; // (=0.5f*0.1f*pow(2,14);)
 

--- a/Config.h
+++ b/Config.h
@@ -359,8 +359,8 @@ namespace Config
   constexpr float track_ptlow = 0.9;
 
   // sorting config (bonus,penalty)
-  constexpr float validHitBonus_ = 5.0;//2.5*4.0; // 4x cmssw bonus (after fix for counts of # missing hits)
-  constexpr float missingHitPenalty_ = 5.0;//20.0/4.0; // 0.25x cmssw penalty (after fix for counts of # missing hits)  
+  constexpr float validHitBonus_ = 5.0;//cmssw bonus = 2.5
+  constexpr float missingHitPenalty_ = 5.0;//cmssw penalty = 20
   constexpr float maxChi2ForRanking_ = 819.2f; // (=0.5f*0.1f*pow(2,14);)
 
   // Threading

--- a/Track.h
+++ b/Track.h
@@ -547,6 +547,9 @@ inline int getScoreCalc(const unsigned int seedtype,
   //if(chi2>Config::maxChi2ForRanking_) chi2=Config::maxChi2ForRanking_;
   int score = 0;
   float score_ = 0.f;
+  ////// V2 of candidate score (simplified score, after fix for counts of # missing hits):
+  score_ = Config::validHitBonus_*nfoundhits - Config::missingHitPenalty_*nmisshits - chi2;
+  if(pt<0.9f && seedtype==2) score_ -= 0.5f*(Config::validHitBonus_)*nfoundhits;
   /*
   ////// V0 of candidate score (before fix for counts of # missing hits):
   // For high pT central tracks: double valid hit bonus
@@ -570,6 +573,7 @@ inline int getScoreCalc(const unsigned int seedtype,
   */
   ////// V1 of candidate score (after fix for counts of # missing hits):
   // For high pT central tracks: 4x valid hit bonus and 0.25x missing hit penalty
+  /*
   if(seedtype==1){
     score_ = (Config::validHitBonus_*4.0f)*nfoundhits - Config::missingHitPenalty_*nmisshits*0.25f - chi2;
     if(pt<0.9f) score_ -= 0.25f*(Config::validHitBonus_)*nfoundhits;
@@ -587,6 +591,8 @@ inline int getScoreCalc(const unsigned int seedtype,
     if(pt<0.9f) score_ -= 0.2f*(Config::validHitBonus_)*nfoundhits;
     if(nfoundhits>8) score_ += (Config::validHitBonus_)*nfoundhits;
   }
+  */
+  if(score > 16000 && !Config::silent) std::cout << "WARNING!! Might be facing score overflow, which leads to discrepancies between STD and CE!" << std::endl;
   score = (int)(floor(10.f * score_ + 0.5));
   return score;
 }

--- a/Track.h
+++ b/Track.h
@@ -592,7 +592,6 @@ inline int getScoreCalc(const unsigned int seedtype,
     if(nfoundhits>8) score_ += (Config::validHitBonus_)*nfoundhits;
   }
   */
-  if(score > 16000 && !Config::silent) std::cout << "WARNING!! Might be facing score overflow, which leads to discrepancies between STD and CE!" << std::endl;
   score = (int)(floor(10.f * score_ + 0.5));
   return score;
 }

--- a/plotting/PlotValidation.cpp
+++ b/plotting/PlotValidation.cpp
@@ -1034,7 +1034,7 @@ void PlotValidation::SetupBins()
   PlotValidation::SetupFixedBins(110,0,1.1,fFracHitsBins);
 
   // track score bins
-  PlotValidation::SetupFixedBins(1699,-16990,16990,fScoreBins);
+  PlotValidation::SetupFixedBins(50,-500,5000,fScoreBins);
 
   // dNhits
   PlotValidation::SetupFixedBins(40,-20,20,fDNHitsBins);


### PR DESCRIPTION
This PR addresses things that were discussed in issues [#195](https://github.com/trackreco/mkFit/issues/195), [#231](https://github.com/trackreco/mkFit/issues/231), and [#234](https://github.com/trackreco/mkFit/issues/234).

By simplifying the score calculation and reducing the hit bonus from 10 to 5, we see a large improvement in efficiency and a slight improvement in timing using our new MTV-require-seeds validation. This is a preliminary retuning, but I propose to use it as the new baseline for further optimizations.

The standalone results can be found [here](http://areinsvo.web.cern.ch/areinsvo/MkFit/OptimizeAug2019/), for both the previous validation definitions and the mtv-require-seeds validation. The results when run within CMSSW_10_4 can be found [here](http://areinsvo.web.cern.ch/areinsvo/MkFit/CMSSW_Integration/Aug2019_Optimization).

See also the slides presented in one of our mkFit meetings [here](https://indico.cern.ch/event/827099/contributions/3460338/attachments/1894190/3124594/OptimizeEfficiency_Aug2019.pdf).