### PR TITLE
Change found hit bonus to 7.5

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -359,7 +359,7 @@ namespace Config
   constexpr float track_ptlow = 0.9;
 
   // sorting config (bonus,penalty)
-  constexpr float validHitBonus_ = 5.0;//cmssw bonus = 2.5
+  constexpr float validHitBonus_ = 7.5;//cmssw bonus = 2.5
   constexpr float missingHitPenalty_ = 5.0;//cmssw penalty = 20
   constexpr float maxChi2ForRanking_ = 819.2f; // (=0.5f*0.1f*pow(2,14);)
 


### PR DESCRIPTION
Changing the hit bonus to 7.5 maintains a track building efficiency comparable to CMSSW but improves the number of strip layers in the built tracks (compared to the hit bonus of 5). Obviously this still doesn't represent a fine tuning, but it is a better set of comparison plots to use for the POG update than my initial guess of 5. Mario said he might have time to work on a further optimization in the next week.

Standalone validation plots: http://areinsvo.web.cern.ch/areinsvo/MkFit/Benchmarks/PR240/standalone
MTV plots (clean version): http://areinsvo.web.cern.ch/areinsvo/MkFit/Benchmarks/PR240/plots_NewScore_Bonus7p5 
MTV plots (messy version, with old mkFit score, new mkFit score with bonus of 5, and new mkFit score with bonus of 7.5): http://areinsvo.web.cern.ch/areinsvo/MkFit/Benchmarks/PR240/plots_compareScores/
A few notable plots include the efficiency comparison [here](http://areinsvo.web.cern.ch/areinsvo/MkFit/Benchmarks/PR240/plots_compareScores/plots_building_initialStep/effandfakePtEtaPhi.pdf) and the comparison of the number of layers in the built tracks [here](http://areinsvo.web.cern.ch/areinsvo/MkFit/Benchmarks/PR240/plots_compareScores/plots_building_initialStep/hitsLayers.pdf).