### PR TITLE
Add support pixel triplet seeds

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -331,7 +331,6 @@ namespace Config
   extern float maxdRSquared;
 
   // config on seed cleaning
-  constexpr int minNHits_seedclean = 4;
   constexpr float track1GeVradius = 87.6; // = 1/(c*B)
   constexpr float c_etamax_brl = 0.9;
   constexpr float c_dpt_brl_0 = 0.025;

--- a/Event.cc
+++ b/Event.cc
@@ -808,7 +808,6 @@ void Event::print_tracks(const TrackVec& tracks, bool print_hits) const
 int Event::clean_cms_seedtracks()
 {
 
-  const int minNHits     = Config::minNHits_seedclean;
   const float etamax_brl = Config::c_etamax_brl;
   const float dpt_brl_0  = Config::c_dpt_brl_0;
   const float dpt_ec_0   = Config::c_dpt_ec_0;
@@ -871,7 +870,6 @@ int Event::clean_cms_seedtracks()
   for(int ts=0; ts<ns; ts++){
 
     if (not writetrack[ts]) continue;//FIXME: this speed up prevents transitive masking; check build cost!
-    if (nHits[ts] < minNHits) continue;
 
     const float oldPhi1 = oldPhi[ts];
     const float pos2_first = pos2[ts];
@@ -881,8 +879,6 @@ int Event::clean_cms_seedtracks()
 
     //#pragma simd /* Vectorization via simd had issues with icc */
     for (int tss= ts+1; tss<ns; tss++){
-
-      if (nHits[tss] < minNHits) continue;
 
       const float Pt2 = pt[tss];
 

--- a/README.md
+++ b/README.md
@@ -559,13 +559,13 @@ named as initialStep)
 ```bash
 # in CMSSW_10_4_0_patch1/src
 
-# sample = 10mu, ttbarnopu, ttbar_pu50, ttbar_pu70
+# sample = 10mu, ttbarnopu, ttbarpu50, ttbarpu70
 # mkfit = 1, 0
 # timing = 0, 1
 # (maxEvents = 0, <N>, -1)
 # nthreads = 1, <N>
 # nstreams = 0, <N>
-cmsRun RecoTracker/MkFit/test/reco_cfg.py sample=ttbar_pu70 timing=1
+cmsRun RecoTracker/MkFit/test/reco_cfg.py sample=ttbarpu50 timing=1
 ```
 * The default values for the command line parameters are the first ones.
 * `mkfit=1` runs MkFit, `0` runs CMSSW tracking
@@ -608,9 +608,20 @@ HLT reconstruction
 ```bash
 # in CMSSW_10_4_0_patch1/src
 
-cmsRun RecoTracker/MkFit/test/hlt_cfg.py sample=ttbar_pu70 timing=1
+# in addition to the offline tracking options
+# hltOnDemand = 0, 1
+# hltIncludeFourthHit = 0, 1
+cmsRun RecoTracker/MkFit/test/hlt_cfg.py sample=ttbarpu50 timing=1
 ```
-* Options and behavior is the same as for the offline reconstruction above
+* The default values for the command line parameters are the first ones.
+* For options that are same as in offline tracking, see above
+* Setting `hltOnDemand=1` makes the strip local reconstruction to be
+  run in the "on-demand" mode (which is the default in real HLT but
+  not here). Note that `hltOnDemand=1` works only with `mkfit=0`.
+* Setting `hltIncludeFourthHit=1` changes the (HLT-default) behavior
+  of the EDProducer that converts pixel tracks to `TrajectorySeed`
+  objects to include also the fourth, outermost hit of the pixel track
+  in the seed.
 
 DQM harvesting (unless running timing)
 ```bash

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -189,25 +189,27 @@ MkBuilder::MkBuilder() :
 
   { SteeringParams &sp = m_steering_params[TrackerInfo::Reg_Endcap_Neg];
     sp.reserve_plan(3 + 3 + 6 + 18);
-    sp.fill_plan(0, 2, false, true);
-    sp.append_plan(45, true);
+    sp.fill_plan(0, 1, false, true); // bk-fit only
+    sp.append_plan( 2, true);        // pick-up only
+    sp.append_plan(45, false);
     sp.append_plan(46, false);
     sp.append_plan(47, false);
-    sp.fill_plan(48, 53); // TID, 6 layers
+    sp.fill_plan(48, 53); // TID,  6 layers
     sp.fill_plan(54, 71); // TEC, 18 layers
     sp.finalize_plan();
   }
 
   { SteeringParams &sp = m_steering_params[TrackerInfo::Reg_Transition_Neg];
     sp.reserve_plan(3 + 4 + 6 + 6 + 8 + 18);
-    sp.fill_plan(0, 2, false, true);
-    sp.append_plan( 3, true);
-    sp.append_plan(45, true);
+    sp.fill_plan(0, 1, false, true); // bk-fit only
+    sp.append_plan( 2, true);
+    sp.append_plan( 3, false);
+    sp.append_plan(45, false);
     sp.append_plan(46, false);
     sp.append_plan(47, false);
-    sp.fill_plan( 4,  9); // TIB, 6 layers
-    sp.fill_plan(48, 53); // TID, 6 layers
-    sp.fill_plan(10, 17); // TOB, 8 layers
+    sp.fill_plan( 4,  9); // TIB,  6 layers
+    sp.fill_plan(48, 53); // TID,  6 layers
+    sp.fill_plan(10, 17); // TOB,  8 layers
     sp.fill_plan(54, 71); // TEC, 18 layers
     sp.finalize_plan();
   }
@@ -215,34 +217,37 @@ MkBuilder::MkBuilder() :
 
   { SteeringParams &sp = m_steering_params[TrackerInfo::Reg_Barrel];
     sp.reserve_plan(3 + 1 + 6 + 8);
-    sp.fill_plan(0, 2, false, true);
-    sp.append_plan(3, true); // pickup-only
-    sp.fill_plan( 4,  9);    // TIB, 6 layers
-    sp.fill_plan(10, 17);    // TOB, 8 layers
+    sp.fill_plan(0, 1, false, true); // bk-fit only
+    sp.append_plan( 2, true);        // pickup-only
+    sp.append_plan( 3, false);
+    sp.fill_plan( 4,  9); // TIB, 6 layers
+    sp.fill_plan(10, 17); // TOB, 8 layers
     sp.finalize_plan();
   }
 
   { SteeringParams &sp = m_steering_params[TrackerInfo::Reg_Transition_Pos];
     sp.reserve_plan(3 + 4 + 6 + 6 + 8 + 18);
-    sp.fill_plan(0, 2, false, true);
-    sp.append_plan( 3, true);
-    sp.append_plan(18, true);
+    sp.fill_plan(0, 1, false, true); // bk-fit only
+    sp.append_plan( 2, true);        // pickup-only
+    sp.append_plan( 3, false);
+    sp.append_plan(18, false);
     sp.append_plan(19, false);
     sp.append_plan(20, false);
-    sp.fill_plan( 4,  9); // TIB, 6 layers
-    sp.fill_plan(21, 26); // TID, 6 layers
-    sp.fill_plan(10, 17); // TOB, 8 layers
+    sp.fill_plan( 4,  9); // TIB,  6 layers
+    sp.fill_plan(21, 26); // TID,  6 layers
+    sp.fill_plan(10, 17); // TOB,  8 layers
     sp.fill_plan(27, 44); // TEC, 18 layers
     sp.finalize_plan();
   }
 
   { SteeringParams &sp = m_steering_params[TrackerInfo::Reg_Endcap_Pos];
     sp.reserve_plan(3 + 3 + 6 + 18);
-    sp.fill_plan(0, 2, false, true);
-    sp.append_plan(18, true);
+    sp.fill_plan(0, 1, false, true); // bk-fit only
+    sp.append_plan( 2, true);        // pickup-only
+    sp.append_plan(18, false);
     sp.append_plan(19, false);
     sp.append_plan(20, false);
-    sp.fill_plan(21, 26); // TID, 6 layers
+    sp.fill_plan(21, 26); // TID,  6 layers
     sp.fill_plan(27, 44); // TEC, 18 layers
     sp.finalize_plan();
   }
@@ -782,10 +787,7 @@ inline void MkBuilder::fit_one_seed_set(TrackVec& seedtracks, int itrack, int en
 
   if (Config::cf_seeding) mkfttr->ConformalFitTracks(false, itrack, end);
 
-  if (Config::seedInput != cmsswSeeds)
-  {
-    mkfttr->FitTracksSteered(is_brl, end - itrack, m_event, Config::seed_fit_pflags);
-  }
+  mkfttr->FitTracksSteered(is_brl, end - itrack, m_event, Config::seed_fit_pflags);
 
   mkfttr->OutputFittedTracksAndHitIdx(m_event->seedTracks_, itrack, end, false);
 }
@@ -1545,7 +1547,12 @@ void MkBuilder::PrepareSeeds()
   //0 = not set; 1 = high pT central seeds; 2 = low pT endcap seeds; 3 = all other seeds
   assign_seedtype_forranking();
 
-  fit_seeds();
+  // Do not refit cmssw seeds (this if was nested in fit_one_seed_set() until now).
+  // Eventually we can add force-refit option.
+  if (Config::seedInput != cmsswSeeds)
+  {
+    fit_seeds();
+  }
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This PR is to add support for pixel triplet seeds in order to work around a "feature" of CMSSW EDProducer that converts pixel reco::Tracks to TrajectorySeeds (used in the HLT menu today) that ignores the fourth hit of the seed (in the context of #236).

First step is to remove the "minimum number of hits in a seed" cut from the seed cleaner, but that turned out to be insufficient. The story continues in the comments.

