### PR TITLE
Track Kaboom

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -107,9 +107,9 @@ namespace Config
   // namespace, too.
   // XXXX This needs to be generalized for other geometries !
   // TrackerInfo more or less has all this information (or could have it).
-  extern    int   nTotalLayers;        // To be set by geometry plugin.
-  constexpr int   nMaxSimHits    = 32; // Assuming dual hit on every barrel / endcap edge -> used in tkNtuple
-  constexpr int   nMaxTrkHits    = nMaxSimHits; // Used for array sizes in MkFitter and Track
+  extern    int   nTotalLayers;          // To be set by geometry plugin.
+  constexpr int   nMaxTrkHits      = 64; // Used for array sizes in MkFitter/Finder, max hits in toy MC
+  constexpr int   nAvgSimHits      = 32; // Used for reserve() calls for sim hits/states
 
   constexpr float fRadialSpacing   = 4.;
   constexpr float fRadialExtent    = 0.01;
@@ -198,11 +198,6 @@ namespace Config
   constexpr float varXY       = Config::hitposerrXY * Config::hitposerrXY;
   constexpr float varZ        = Config::hitposerrZ  * Config::hitposerrZ;
   constexpr float varR        = Config::hitposerrR  * Config::hitposerrR;
-
-  // XXMT4K OK ... what do we do with this guy? MaxTotHit / AvgTotHit ... ?
-  // For now setting it to nMaxTrkLayers which is too big ... but it seems to be
-  // only used for vector::reserve() ...
-  constexpr int nTotHit = Config::nMaxSimHits; // for now one hit per layer for sim
 
   // scattering simulation
   constexpr float X0 = 9.370; // cm, from http://pdg.lbl.gov/2014/AtomicNuclearProperties/HTML/silicon_Si.html // Pb = 0.5612 cm
@@ -361,6 +356,7 @@ namespace Config
   // sorting config (bonus,penalty)
   constexpr float validHitBonus_ = 7.5;//cmssw bonus = 2.5
   constexpr float missingHitPenalty_ = 5.0;//cmssw penalty = 20
+  // QQQQ do we still need this?
   constexpr float maxChi2ForRanking_ = 819.2f; // (=0.5f*0.1f*pow(2,14);)
 
   // Threading

--- a/Event.h
+++ b/Event.h
@@ -36,6 +36,9 @@ public:
 
   void write_out(DataFile &data_file);
   void read_in  (DataFile &data_file, FILE *in_fp=0);
+  int  write_tracks(FILE *fp, const TrackVec& tracks);
+  int  read_tracks (FILE *fp,       TrackVec& tracks, bool skip_reading = false);
+
   void setInputFromCMSSW(std::vector<HitVec> hits, TrackVec seeds);
 
   void kludge_cms_hit_errors();
@@ -91,9 +94,10 @@ typedef std::vector<Event> EventVec;
 struct DataFileHeader
 {
   int f_magic          = 0xBEEF;
-  int f_format_version = 3;
+  int f_format_version = 4;
   int f_sizeof_track   = sizeof(Track);
-  int f_n_max_trk_hits = Config::nMaxTrkHits;
+  int f_sizeof_hit     = sizeof(Hit);
+  int f_sizeof_hot     = sizeof(HitOnTrack);
   int f_n_layers       = -1;
   int f_n_events       = -1;
 

--- a/Hit.h
+++ b/Hit.h
@@ -272,6 +272,12 @@ struct HitOnTrack
 
   HitOnTrack()             : index(-1), layer (-1) {}
   HitOnTrack(int i, int l) : index( i), layer ( l) {}
+
+  bool operator<(const HitOnTrack o) const
+  {
+    if (layer != o.layer) return layer < o.layer;
+    return index < o.index;
+  }
 };
 
 typedef std::vector<HitOnTrack> HoTVec;

--- a/Hit.h
+++ b/Hit.h
@@ -188,8 +188,10 @@ class Hit
 {
 public:
   Hit() : mcHitID_(-1) {}
+
   Hit(const SVector3& position, const SMatrixSym33& error, int mcHitID = -1)
-    : state_(position, error), mcHitID_(mcHitID) {}
+    : state_(position, error), mcHitID_(mcHitID)
+  {}
 
   ~Hit(){}
 
@@ -251,10 +253,59 @@ public:
   int mcHitID() const { return mcHitID_; }
   int layer(const MCHitInfoVec& globalMCHitInfo) const { return globalMCHitInfo[mcHitID_].layer(); }
   int mcTrackID(const MCHitInfoVec& globalMCHitInfo) const { return globalMCHitInfo[mcHitID_].mcTrackID(); }
-  
+
+  struct PackedData {
+    union {
+      struct {
+        unsigned int detid_in_layer : 12;
+        unsigned int charge_pcm     :  8;
+        unsigned int span_rows      :  3;
+        unsigned int span_cols      :  3;
+      };
+      unsigned int _raw_;
+    };
+
+    PackedData() : _raw_(0) {}
+
+    void set_charge_pcm(int cpcm)
+    {
+      if (cpcm < 1620) charge_pcm = 0;
+      else             charge_pcm = std::min(0xff, ((cpcm - 1620) >> 3) + 1);
+    }
+    unsigned int get_charge_pcm() const
+    {
+      if (charge_pcm == 0) return 0;
+      else                 return ((charge_pcm - 1) << 3) + 1620;
+    }
+  };
+
+  unsigned int detIDinLayer() const { return pdata_.detid_in_layer; }
+  unsigned int chargePerCM()  const { return pdata_.get_charge_pcm(); }
+  unsigned int spanRows()     const { return pdata_.span_rows + 1; }
+  unsigned int spanCols()     const { return pdata_.span_cols + 1; }
+
+  static unsigned int maxChargePerCM() { return 1620 + (0xfe << 3); }
+  static unsigned int maxSpan()        { return 8; }
+
+  void setupAsPixel(unsigned int id, int rows, int cols)
+  {
+    pdata_.detid_in_layer = id;
+    pdata_.charge_pcm = 0xff;
+    pdata_.span_rows = std::min(0x7, rows - 1);
+    pdata_.span_cols = std::min(0x7, cols - 1);
+  }
+
+  void setupAsStrip(unsigned int id, int cpcm, int rows)
+  {
+    pdata_.detid_in_layer = id;
+    pdata_.set_charge_pcm(cpcm);
+    pdata_.span_rows = std::min(0x7, rows - 1);
+  }
+
 private:
   MeasurementState state_;
-  int mcHitID_;
+  int              mcHitID_;
+  PackedData       pdata_;
 };
 
 typedef std::vector<Hit> HitVec;

--- a/Simulation.cc
+++ b/Simulation.cc
@@ -85,15 +85,15 @@ roll_eta_dice:
   }
   int simLayer = -1;
 
-  hits.reserve(Config::nTotHit);
-  initTSs.reserve(Config::nTotHit);
+  hits.reserve(Config::nAvgSimHits);
+  initTSs.reserve(Config::nAvgSimHits);
 
   // XXMT4M - This should become while not in outer layer (or at least propState.state == invalid)
   // Try the invalid thingy first ... but would be good to also know what layers are final.
 
   const PropagationFlags pflags(PF_use_param_b_field);
 
-  for (int ihit = 0; ihit < Config::nTotHit; ++ihit)
+  for (int ihit = 0; ihit < Config::nMaxTrkHits; ++ihit)
   {
     dprintf("\n================================================================================\n");
     dprintf("=== Going for next hit %d from layer %d, xyrzphi=(%f,%f,%f,%f,%f)\n",

--- a/TTreeValidation.h
+++ b/TTreeValidation.h
@@ -229,7 +229,6 @@ public:
   float minSimPt_=0.,maxSimPt_=0.;
   float hitposerrXY_=0.,hitposerrZ_=0.,hitposerrR_=0.;
   float varXY_=0.,varZ_=0.;
-  int   nTotHit_=0;
   float ptinverr049_=0.,phierr049_=0.,thetaerr049_=0.,ptinverr012_=0.,phierr012_=0.,thetaerr012_=0.;
 
   // CMSSW Efficiency tree

--- a/Track.cc
+++ b/Track.cc
@@ -73,12 +73,11 @@ SMatrix66 TrackState::jacobianCartesianToCCS(float px,float py,float pz) const {
   return jac;
 }
 
-
 //==============================================================================
-// Track
+// TrackBase
 //==============================================================================
 
-bool Track::hasSillyValues(bool dump, bool fix, const char* pref)
+bool TrackBase::hasSillyValues(bool dump, bool fix, const char* pref)
 {
   bool is_silly = false;
   for (int i = 0; i < LL; ++i)
@@ -90,7 +89,7 @@ bool Track::hasSillyValues(bool dump, bool fix, const char* pref)
         if ( ! is_silly)
         {
           is_silly = true;
-          if (dump) printf("%s (label=%d):", pref, label_);
+          if (dump) printf("%s (label=%d):", pref, label());
         }
         if (dump) printf(" (%d,%d)=%e", i, j, state_.errors.At(i,j));
         if (fix)  state_.errors.At(i,j) = 1;
@@ -101,7 +100,9 @@ bool Track::hasSillyValues(bool dump, bool fix, const char* pref)
   return is_silly;
 }
 
-//------------------------------------------------------------------------------
+//==============================================================================
+// Track
+//==============================================================================
 
 void Track::sortHitsByLayer()
 {

--- a/Track.cc
+++ b/Track.cc
@@ -104,6 +104,12 @@ bool TrackBase::hasSillyValues(bool dump, bool fix, const char* pref)
 // Track
 //==============================================================================
 
+void Track::resizeHitsForInput()
+{
+  bzero(&hitsOnTrk_, sizeof(hitsOnTrk_));
+  hitsOnTrk_.resize(lastHitIdx_ + 1);
+}
+
 void Track::sortHitsByLayer()
 {
   std::sort(& hitsOnTrk_[0], & hitsOnTrk_[lastHitIdx_ + 1],
@@ -397,7 +403,7 @@ void TrackExtra::setMCTrackIDInfo(const Track& trk, const std::vector<HitVec>& l
     }
   
     // total found hits in hit index array, excluding seed if necessary
-    const int nCandHits = ((Config::mtvLikeValidation || isSeed) ? trk.nStoredFoundHits() : trk.nStoredFoundHits() - nSeedHits);
+    const int nCandHits = ((Config::mtvLikeValidation || isSeed) ? trk.nFoundHits() : trk.nFoundHits() - nSeedHits);
 
     // 75% or 50% matching criterion 
     if ( ( Config::mtvLikeValidation ? (4*mccount > 3*nCandHits) : (2*mccount >= nCandHits) ) )
@@ -569,7 +575,7 @@ void TrackExtra::setCMSSWTrackIDInfoByTrkParams(const Track& trk, const std::vec
 
   // other important info
   nHitsMatched_ = nHitsMatched;
-  fracHitsMatched_ = float(nHitsMatched_) / float(trk.nStoredFoundHits()-nSeedHits); // seed hits may already be included!
+  fracHitsMatched_ = float(nHitsMatched_) / float(trk.nFoundHits()-nSeedHits); // seed hits may already be included!
 }
 
 void TrackExtra::setCMSSWTrackIDInfoByHits(const Track& trk, const LayIdxIDVecMapMap& cmsswHitIDMap, const TrackVec& cmsswtracks, 

--- a/Track.h
+++ b/Track.h
@@ -198,22 +198,21 @@ public:
 
   CUDA_CALLABLE int   charge() const { return state_.charge; }
   CUDA_CALLABLE float chi2()   const { return chi2_; }
+  CUDA_CALLABLE float score()  const { return score_; }
   CUDA_CALLABLE int   label()  const { return label_; }
 
   CUDA_CALLABLE void  setCharge(int chg)  { state_.charge = chg; }
   CUDA_CALLABLE void  setChi2(float chi2) { chi2_ = chi2; }
+  CUDA_CALLABLE void  setScore(float s)   { score_ = s; }
   CUDA_CALLABLE void  setLabel(int lbl)   { label_ = lbl; }
 
   bool  hasSillyValues(bool dump, bool fix, const char* pref="");
 
   // ------------------------------------------------------------------------
 
-  struct Status
-  {
-    union
-    {
-      struct
-      {
+  struct Status {
+    union  {
+      struct {
         // Set to true for short, low-pt CMS tracks. They do not generate mc seeds and
         // do not enter the efficiency denominator.
         bool not_findable : 1;
@@ -226,22 +225,14 @@ public:
         // Production type (most useful for sim tracks): 0, 1, 2, 3 for unset, signal, in-time PU, oot PU
         unsigned int prod_type : 2;
 
-        // Set to true when hit-on-track array grows to the limits and last hits
-        // have to get overwritten.
-        bool has_non_stored_hits : 1;
-
         // Seed type for candidate ranking: 0 = not set; 1 = high pT central seeds; 2 = low pT endcap seeds; 3 = all other seeds
         unsigned int seed_type : 2;
 
-	// Candidate score for ranking (12 bits for value + 1 bit for sign):
-	int cand_score : 15;
-
-	//Whether or not the track matched to another track and had the lower cand score
+	// Whether or not the track matched to another track and had the lower cand score
 	bool duplicate : 1;
 
-        // The rest, testing if mixing int and unsigned int is ok.
-        int          _some_free_bits_ : 3;
-        unsigned int _more_free_bits_ : 6;
+        // The remaining bits.
+        unsigned int _free_bits_ : 25;
 
       };
 
@@ -266,30 +257,22 @@ public:
   void setSeedTypeForRanking(unsigned int r) { status_.seed_type = r; }
   unsigned int getSeedTypeForRanking() const { return status_.seed_type; }
 
-  void setCandScore(int r) { status_.cand_score = r; }
-  int getCandScore() const { return status_.cand_score; }
   void setDuplicateValue(bool d) {status_.duplicate = d;}
   bool getDuplicateValue() const {return status_.duplicate;}
   enum class ProdType { NotSet = 0, Signal = 1, InTimePU = 2, OutOfTimePU = 3};
   ProdType prodType()  const { return ProdType(status_.prod_type); }
   void setProdType(ProdType ptyp) { status_.prod_type = static_cast<unsigned int>(ptyp); }
 
-  bool hasNonStoredHits() const { return status_.has_non_stored_hits; }
-  void setHasNonStoredHits()    { status_.has_non_stored_hits = true; }
-
   // To be used later
   // bool isStopped() const { return status_.stopped; }
   // void setStopped()      { status_.stopped = true; }
-
-  // For export from TrackCand
-  void resetHitsFound() { lastHitIdx_ = -1; nFoundHits_ = 0; }
 
   // ------------------------------------------------------------------------
 
 protected:
   TrackState    state_;
   float         chi2_       =  0.;
-
+  float         score_      =  0.;
   short int     lastHitIdx_ = -1;
   short int     nFoundHits_ =  0;
   Status        status_;
@@ -315,14 +298,19 @@ public:
   CUDA_CALLABLE
   Track() {}
 
-  Track(const TrackBase& base) :
+  explicit Track(const TrackBase& base) :
     TrackBase(base)
-  {}
+  {
+    // Reset hit counters -- caller has to initialize hits.
+    lastHitIdx_ = -1;
+    nFoundHits_ =  0;
+  }
 
   CUDA_CALLABLE
   Track(const TrackState& state, float chi2, int label, int nHits, const HitOnTrack* hits) :
     TrackBase(state, chi2, label)
   {
+    reserveHits(nHits);
     for (int h = 0; h < nHits; ++h)
     {
       addHitIdx(hits[h].index, hits[h].layer, 0.0f);
@@ -332,6 +320,11 @@ public:
   Track(int charge, const SVector3& position, const SVector3& momentum,
         const SMatrixSym66& errors, float chi2) :
     TrackBase(charge, position, momentum, errors, chi2)
+  {}
+
+  Track(const Track &t) :
+    TrackBase  (t),
+    hitsOnTrk_ (t.hitsOnTrk_)
   {}
 
   CUDA_CALLABLE
@@ -374,31 +367,28 @@ public:
     }
   }
 
+  // The following 2 (well, 3) funcs to be fixed once we move lastHitIdx_ and nFoundHits_
+  // out of TrackBase. If we do it.
+  void reserveHits(int nHits) { hitsOnTrk_.reserve(nHits); }
+
+  CUDA_CALLABLE
+  void resetHits() { lastHitIdx_ = -1; nFoundHits_ =  0; hitsOnTrk_.clear(); }
+
+  // Hackish for MkFinder::copy_out ... to be reviewed
+  void resizeHits(int nHits, int nFoundHits)
+  { hitsOnTrk_.resize(nHits); lastHitIdx_ = nHits - 1; nFoundHits_ = nFoundHits; }
+
+  void resizeHitsForInput();
+
   CUDA_CALLABLE
   void addHitIdx(int hitIdx, int hitLyr, float chi2)
   {
-    if (lastHitIdx_ < Config::nMaxTrkHits - 1)
+    hitsOnTrk_.push_back( { hitIdx, hitLyr } );
+    ++lastHitIdx_;
+    if (hitIdx >= 0 || hitIdx == -9)
     {
-      hitsOnTrk_[++lastHitIdx_] = { hitIdx, hitLyr };
-      if (hitIdx >= 0 || hitIdx == -9) { ++nFoundHits_; chi2_+=chi2; }
-    }
-    else
-    {
-      // printf("WARNING Track::addHitIdx hit-on-track limit reached for label=%d\n", label_);
-      // print("Track", -1, *this, true);
-
-      if (hitIdx >= 0 || hitIdx == -9)
-      {
-        ++nFoundHits_;
-        chi2_ += chi2;
-        hitsOnTrk_[lastHitIdx_] = { hitIdx, hitLyr };
-      }
-      else if (hitIdx == -2)
-      {
-        hitsOnTrk_[lastHitIdx_] = { hitIdx, hitLyr };
-      }
-
-      setHasNonStoredHits();
+      ++nFoundHits_;
+      chi2_ += chi2;
     }
   }
 
@@ -419,13 +409,13 @@ public:
   int getLastFoundHitPos() const
   {
     int hi = lastHitIdx_;
-    while (hitsOnTrk_[hi].index < 0) --hi;
+    while (hi >= 0 && hitsOnTrk_[hi].index < 0) --hi;
     return hi;
   }
 
-  HitOnTrack getLastFoundHitOnTrack() const { return hitsOnTrk_[getLastFoundHitPos()]; }
-  int        getLastFoundHitIdx()     const { return hitsOnTrk_[getLastFoundHitPos()].index; }
-  int        getLastFoundHitLyr()     const { return hitsOnTrk_[getLastFoundHitPos()].layer; }
+  HitOnTrack getLastFoundHitOnTrack() const { int p = getLastFoundHitPos(); return p >= 0 ? hitsOnTrk_[p] : HitOnTrack(-1, -1); }
+  int        getLastFoundHitIdx()     const { int p = getLastFoundHitPos(); return p >= 0 ? hitsOnTrk_[p].index : -1; }
+  int        getLastFoundHitLyr()     const { int p = getLastFoundHitPos(); return p >= 0 ? hitsOnTrk_[p].layer : -1; }
 
   int getLastFoundMCHitID(const std::vector<HitVec>& globalHitVec) const
   {
@@ -447,17 +437,11 @@ public:
     return mcHitID;
   }
 
-  const HitOnTrack* getHitsOnTrackArray() const { return hitsOnTrk_; }
-  const HitOnTrack* BeginHitsOnTrack()    const { return hitsOnTrk_; }
-  const HitOnTrack* EndHitsOnTrack()      const { return & hitsOnTrk_[lastHitIdx_ + 1]; }
+  const HitOnTrack* getHitsOnTrackArray() const { return hitsOnTrk_.data(); }
+  const HitOnTrack* BeginHitsOnTrack()    const { return hitsOnTrk_.data(); }
+  const HitOnTrack* EndHitsOnTrack()      const { return hitsOnTrk_.data() + (lastHitIdx_ + 1); }
 
-  HitOnTrack* BeginHitsOnTrack_nc() { return hitsOnTrk_; }
-
-  void fillEmptyLayers() {
-    for (int h = lastHitIdx_ + 1; h < Config::nMaxTrkHits; h++) {
-      setHitIdxLyr(h, -1, -1);
-    }
-  }
+  HitOnTrack* BeginHitsOnTrack_nc() { return hitsOnTrk_.data(); }
 
   CUDA_CALLABLE
   void setHitIdx(int posHitIdx, int newIdx) {
@@ -469,30 +453,15 @@ public:
     hitsOnTrk_[posHitIdx] = { newIdx, newLyr };
   }
 
-  void setNFoundHits() {
+  void countAndSetNFoundHits() {
     nFoundHits_=0;
     for (int i = 0; i <= lastHitIdx_; i++) {
       if (hitsOnTrk_[i].index >= 0 || hitsOnTrk_[i].index == -9) nFoundHits_++;
     }
   }
 
-  CUDA_CALLABLE
-  void setNFoundHits(int nHits) { nFoundHits_ = nHits; }
-  void setNTotalHits(int nHits) { lastHitIdx_ = nHits - 1; }
-
-  CUDA_CALLABLE
-  void resetHits() { lastHitIdx_ = -1; nFoundHits_ =  0; }
-
   CUDA_CALLABLE int  nFoundHits() const { return nFoundHits_; }
-  CUDA_CALLABLE int  nTotalHits() const { return lastHitIdx_+1; }
-
-  int nStoredFoundHits() const
-  {
-    int n = 0;
-    for (int i = 0; i <= lastHitIdx_; ++i)
-      if (hitsOnTrk_[i].index >= 0 || hitsOnTrk_[i].index == -9) ++n; 
-    return n;
-  }
+  CUDA_CALLABLE int  nTotalHits() const { return lastHitIdx_ + 1; }
 
   int nInsideMinusOneHits() const
   {
@@ -509,7 +478,7 @@ public:
   int nUniqueLayers() const 
   {
     // make local copy in vector: sort it in place
-    std::vector<HitOnTrack> tmp_hitsOnTrk(hitsOnTrk_,hitsOnTrk_+(lastHitIdx_+1)); 
+    std::vector<HitOnTrack> tmp_hitsOnTrk(hitsOnTrk_.begin(), hitsOnTrk_.end());
     std::sort(tmp_hitsOnTrk.begin(), tmp_hitsOnTrk.end(),
 	      [](const auto & h1, const auto & h2) { return h1.layer < h2.layer; });
 
@@ -546,12 +515,11 @@ public:
     return layers;
   }
 
-
-  CUDA_CALLABLE Track clone() const { return Track(state_,chi2_,label_,nTotalHits(),hitsOnTrk_); }
+  CUDA_CALLABLE Track clone() const { return Track(*this); }
 
 
 private:
-  HitOnTrack    hitsOnTrk_[Config::nMaxTrkHits];
+  std::vector<HitOnTrack>    hitsOnTrk_;
 };
 
 typedef std::vector<Track>    TrackVec;
@@ -574,7 +542,7 @@ inline bool sortByHitsChi2(const Track & cand1, const Track & cand2)
 
 inline bool sortByScoreCand(const Track & cand1, const Track & cand2)
 {
-  return cand1.getCandScore() > cand2.getCandScore();
+  return cand1.score() > cand2.score();
 }
 
 inline bool sortByScoreStruct(const IdxChi2List& cand1, const IdxChi2List& cand2)
@@ -587,22 +555,25 @@ inline bool sortByScoreCandPair(const std::pair<Track, TrackState>& cand1, const
   return sortByScoreCand(cand1.first,cand2.first);
 }
 
-inline int getScoreWorstPossible()
+inline float getScoreWorstPossible()
 {
-  return -0x3FFF; // 14 bits, all ones.
+  return -1e16; // somewhat arbitrary value, used  during finding (will try to take it out)
 }
 
-inline int getScoreCalc(const unsigned int seedtype,
-                        const int nfoundhits,
-                        const int nmisshits,
-                        const float chi2,
-                        const float pt)
+inline float getScoreCalc(const unsigned int seedtype,
+                          const int nfoundhits,
+                          const int nmisshits,
+                          const float chi2,
+                          const float pt)
 {
+  // QQQQ Mario, Allie ... do we want to change this now that score is a float?
+  // In particular, we probably don't need Config::maxChi2ForRanking any more.
+  // Comments below need to be updated.
+
   //// Do not allow for chi2<0 in score calculation
   //if(chi2<0) chi2=0.f;
   //// Do not allow for chi2>2^14/2/10 in score calculation (15 bits for (int) score x 10: 14 bits for score magnitude + 1 bit for sign --> max chi2 = 1/2*1/10*2^14=819.2) 
   //if(chi2>Config::maxChi2ForRanking_) chi2=Config::maxChi2ForRanking_;
-  int score = 0;
   float score_ = 0.f;
   ////// V2 of candidate score (simplified score, after fix for counts of # missing hits):
   score_ = Config::validHitBonus_*nfoundhits - Config::missingHitPenalty_*nmisshits - chi2;
@@ -649,11 +620,10 @@ inline int getScoreCalc(const unsigned int seedtype,
     if(nfoundhits>8) score_ += (Config::validHitBonus_)*nfoundhits;
   }
   */
-  score = (int)(floor(10.f * score_ + 0.5));
-  return score;
+  return score_;
 }
 
-inline int getScoreCand(const Track& cand1)
+inline float getScoreCand(const Track& cand1)
 {
   unsigned int seedtype = cand1.getSeedTypeForRanking();
   int nfoundhits = cand1.nFoundHits();
@@ -667,7 +637,7 @@ inline int getScoreCand(const Track& cand1)
   return getScoreCalc(seedtype,nfoundhits,nmisshits,chi2,pt);
 }
 
-inline int getScoreStruct(const IdxChi2List& cand1)
+inline float getScoreStruct(const IdxChi2List& cand1)
 {
   unsigned int seedtype = cand1.seedtype;
   int nfoundhits = cand1.nhits;

--- a/mkFit/CandCloner.cc
+++ b/mkFit/CandCloner.cc
@@ -40,8 +40,8 @@ void CandCloner::ProcessSeedRange(int is_beg, int is_end)
   {
     std::vector<IdxChi2List>& hitsForSeed = m_hits_to_add[is];
 
-    CombCandidate      &ccand  = cands[m_start_seed + is];
-    std::vector<Track> &extras = (*mp_extra_cands)[is];
+    CombCandidate          &ccand  = cands[m_start_seed + is];
+    std::vector<TrackCand> &extras = (*mp_extra_cands)[is];
     auto extra_i = extras.begin();
     auto extra_e = extras.end();
 
@@ -69,7 +69,7 @@ void CandCloner::ProcessSeedRange(int is_beg, int is_end)
       int num_hits = std::min((int) hitsForSeed.size(), Config::maxCandsPerSeed);
 
       // This is from buffer, we know it was cleared after last usage.
-      std::vector<Track> &cv = t_cands_for_next_lay[is - is_beg];
+      std::vector<TrackCand> &cv = t_cands_for_next_lay[is - is_beg];
 
       int n_pushed = 0;
 
@@ -77,7 +77,7 @@ void CandCloner::ProcessSeedRange(int is_beg, int is_end)
       {
         const IdxChi2List &h2a = hitsForSeed[ih];
 
-        Track cc( ccand[h2a.trkIdx] );
+        TrackCand cc( ccand[h2a.trkIdx] );
         cc.addHitIdx(h2a.hitIdx, m_layer, 0);
         cc.setChi2(h2a.chi2);
         cc.setCandScore(h2a.score);
@@ -96,7 +96,7 @@ void CandCloner::ProcessSeedRange(int is_beg, int is_end)
         // Could also skip storing of cands with last -3 hit.
 
         // Squeeze in extra tracks that are better than current one.
-        while (extra_i != extra_e && sortByScoreCand(*extra_i, cc) && n_pushed < Config::maxCandsPerSeed)
+        while (extra_i != extra_e && sortByScoreTrackCand(*extra_i, cc) && n_pushed < Config::maxCandsPerSeed)
         {
           cv.emplace_back(*extra_i);
           ++n_pushed;
@@ -127,7 +127,7 @@ void CandCloner::ProcessSeedRange(int is_beg, int is_end)
       ccand.resize(cv.size());
       for (size_t ii = 0; ii < cv.size(); ++ii)
       {
-	memcpy( & ccand[ii], & cv[ii], sizeof(Track));
+        ccand[ii] = cv[ii];
       }
       cv.clear();
     }

--- a/mkFit/CandCloner.cc
+++ b/mkFit/CandCloner.cc
@@ -80,13 +80,13 @@ void CandCloner::ProcessSeedRange(int is_beg, int is_end)
         TrackCand cc( ccand[h2a.trkIdx] );
         cc.addHitIdx(h2a.hitIdx, m_layer, 0);
         cc.setChi2(h2a.chi2);
-        cc.setCandScore(h2a.score);
+        cc.setScore(h2a.score);
         // h2a already carries correct score
-        // cc.setCandScore( getScoreCand( cc );
+        // cc.setScore( getScoreCand( cc );
 
         if (h2a.hitIdx == -2)
         {
-          if (h2a.score > ccand.m_best_short_cand.getCandScore())
+          if (h2a.score > ccand.m_best_short_cand.score())
           {
             ccand.m_best_short_cand = cc;
           }

--- a/mkFit/CandCloner.h
+++ b/mkFit/CandCloner.h
@@ -24,7 +24,7 @@ private:
   // Temporaries in ProcessSeedRange(), resized/reserved  in constructor.
 
   // Size of this one is s_max_seed_range
-  std::vector<std::vector<Track> > t_cands_for_next_lay;
+  std::vector<std::vector<TrackCand>> t_cands_for_next_lay;
 
 public:
   CandCloner()
@@ -40,9 +40,9 @@ public:
   {
   }
 
-  void begin_eta_bin(EventOfCombCandidates           *e_o_ccs,
-                     std::vector<std::pair<int,int>> *update_list,
-                     std::vector<std::vector<Track>> *extra_cands,
+  void begin_eta_bin(EventOfCombCandidates               *e_o_ccs,
+                     std::vector<std::pair<int,int>>     *update_list,
+                     std::vector<std::vector<TrackCand>> *extra_cands,
                      int start_seed, int n_seeds)
   {
     mp_event_of_comb_candidates = e_o_ccs;
@@ -170,9 +170,9 @@ public:
   int  m_idx_max, m_idx_max_prev;
   std::vector<std::vector<IdxChi2List>> m_hits_to_add;
 
-  EventOfCombCandidates           *mp_event_of_comb_candidates;
-  std::vector<std::pair<int,int>> *mp_kalman_update_list;
-  std::vector<std::vector<Track>> *mp_extra_cands;
+  EventOfCombCandidates               *mp_event_of_comb_candidates;
+  std::vector<std::pair<int,int>>     *mp_kalman_update_list;
+  std::vector<std::vector<TrackCand>> *mp_extra_cands;
 
 #if defined(CC_TIME_ETA) or defined(CC_TIME_LAYER)
   double    t_eta, t_lay;

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -279,13 +279,13 @@ class TrackCand : public TrackBase
 public:
   TrackCand() {}
 
-  TrackCand(const TrackBase& base, CombCandidate* ccand) :
+  explicit TrackCand(const TrackBase& base, CombCandidate* ccand) :
     TrackBase(base),
     m_comb_candidate(ccand)
   {
-    // Reset position for filling into CombCandidate hit storage.
-    // Caller has to initialize hits.
+    // Reset hit counters -- caller has to initialize hits.
     lastHitIdx_ = -1;
+    nFoundHits_ =  0;
   }
 
   CombCandidate* combCandidate() const { return m_comb_candidate; }
@@ -329,7 +329,7 @@ protected:
 
 inline bool sortByScoreTrackCand(const TrackCand & cand1, const TrackCand & cand2)
 {
-  return cand1.getCandScore() > cand2.getCandScore();
+  return cand1.score() > cand2.score();
 }
 
 inline int getScoreCand(const TrackCand& cand1)
@@ -342,7 +342,7 @@ inline int getScoreCand(const TrackCand& cand1)
   // Do not allow for chi2<0 in score calculation
   if(chi2<0) chi2=0.f;
   // Do not allow for chi2>2^14/2/10 in score calculation (15 bits for (int) score x 10: 14 bits for score magnitude + 1 bit for sign --> max chi2 = 1/2*1/10*2^14=819.2)
-  if(chi2>Config::maxChi2ForRanking_) chi2=Config::maxChi2ForRanking_;
+  if(chi2 > Config::maxChi2ForRanking_) chi2=Config::maxChi2ForRanking_;
   return getScoreCalc(seedtype,nfoundhits,nmisshits,chi2,pt);
 }
 
@@ -356,7 +356,7 @@ public:
   TrackCand    m_best_short_cand;
   SeedState_e  m_state           = Dormant;
   int          m_last_seed_layer = -1;
-  unsigned int m_seed_type       = 0;
+  unsigned int m_seed_type       =  0;
 
   int                  m_hots_size = 0;
   std::vector<HoTNode> m_hots;
@@ -364,7 +364,7 @@ public:
   CombCandidate()
   {
     reserve(Config::maxCandsPerSeed); //we should never exceed this
-    m_best_short_cand.setCandScore( getScoreWorstPossible() );
+    m_best_short_cand.setScore( getScoreWorstPossible() );
 
     // this will be different for CloneEngine and Std, especially as long as we
     // instantiate all candidates before purging them.

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -263,24 +263,168 @@ public:
 
 
 //==============================================================================
-// CombinedCandidate and EventOfCombinedCandidates
+// TrackCand, CombinedCandidate and EventOfCombinedCandidates
 //==============================================================================
+
+struct HoTNode
+{
+  HitOnTrack m_hot;
+  int        m_prev_idx;
+};
+
+class CombCandidate;
+
+class TrackCand : public TrackBase
+{
+public:
+  TrackCand() {}
+
+  TrackCand(const TrackBase& base, CombCandidate* ccand) :
+    TrackBase(base),
+    m_comb_candidate(ccand)
+  {
+    // Reset position for filling into CombCandidate hit storage.
+    // Caller has to initialize hits.
+    lastHitIdx_ = -1;
+  }
+
+  CombCandidate* combCandidate() const { return m_comb_candidate; }
+  void setCombCandidate(CombCandidate* cc) { m_comb_candidate = cc; }
+
+  int  lastCcIndex()  const { return lastHitIdx_; }
+  int  nFoundHits()   const { return nFoundHits_; }
+  int  nMissingHits() const { return nMissingHits_; }
+  int  nTotalHits()   const { return nFoundHits_ + nMissingHits_; }
+
+  void setLastCcIndex(int i)  { lastHitIdx_   = i; }
+  void setNFoundHits(int n)   { nFoundHits_   = n; }
+  void setNMissingHits(int n) { nMissingHits_ = n; }
+
+  int  nInsideMinusOneHits() const { return nInsideMinusOneHits_; }
+  int  nTailMinusOneHits()   const { return nTailMinusOneHits_; }
+
+  void setNInsideMinusOneHits(int n) { nInsideMinusOneHits_ = n; }
+  void setNTailMinusOneHits(int n)   { nTailMinusOneHits_ = n; }
+
+  // Inlines after definition of CombCandidate
+
+  HitOnTrack getLastHitOnTrack() const;
+  int        getLastHitIdx()     const;
+  int        getLastHitLyr()     const;
+
+  void addHitIdx(int hitIdx, int hitLyr, float chi2);
+
+  Track exportTrack() const;
+
+protected:
+  CombCandidate *m_comb_candidate = nullptr;
+  // using from TrackBase:
+  // short int lastHitIdx_
+  // short int nFoundHits_
+  short int    nMissingHits_        = 0;
+
+  short int    nInsideMinusOneHits_ = 0;
+  short int    nTailMinusOneHits_   = 0;
+};
+
+inline bool sortByScoreTrackCand(const TrackCand & cand1, const TrackCand & cand2)
+{
+  return cand1.getCandScore() > cand2.getCandScore();
+}
+
+inline int getScoreCand(const TrackCand& cand1)
+{
+  unsigned int seedtype = cand1.getSeedTypeForRanking();
+  int nfoundhits = cand1.nFoundHits();
+  int nmisshits = cand1.nInsideMinusOneHits();
+  float pt = cand1.pT();
+  float chi2 = cand1.chi2();
+  // Do not allow for chi2<0 in score calculation
+  if(chi2<0) chi2=0.f;
+  // Do not allow for chi2>2^14/2/10 in score calculation (15 bits for (int) score x 10: 14 bits for score magnitude + 1 bit for sign --> max chi2 = 1/2*1/10*2^14=819.2)
+  if(chi2>Config::maxChi2ForRanking_) chi2=Config::maxChi2ForRanking_;
+  return getScoreCalc(seedtype,nfoundhits,nmisshits,chi2,pt);
+}
 
 // This inheritance sucks but not doing it will require more changes.
 
-class CombCandidate : public std::vector<Track>
+class CombCandidate : public std::vector<TrackCand>
 {
 public:
   enum SeedState_e { Dormant = 0, Finding, Finished };
 
-  Track        m_best_short_cand;
+  TrackCand    m_best_short_cand;
   SeedState_e  m_state           = Dormant;
   int          m_last_seed_layer = -1;
-  unsigned int m_seed_type = 0;
+  unsigned int m_seed_type       = 0;
+
+  int                  m_hots_size = 0;
+  std::vector<HoTNode> m_hots;
+
+  CombCandidate()
+  {
+    reserve(Config::maxCandsPerSeed); //we should never exceed this
+    m_best_short_cand.setCandScore( getScoreWorstPossible() );
+
+    // this will be different for CloneEngine and Std, especially as long as we
+    // instantiate all candidates before purging them.
+    // ce:  N_layer * N_cands ~~ 20 * 6 = 120
+    // std: i don't know, let's say double
+    m_hots.reserve(256);
+  }
+
+  void Reset()
+  {
+    clear();
+    m_hots_size = 0;
+    m_hots.clear();
+  }
+
+  void ImportSeed(const Track& seed);
+
+  int AddHit(const HitOnTrack& hot, int prev_idx)
+  {
+    m_hots.push_back({hot, prev_idx});
+    return m_hots_size++;
+  }
 
   void MergeCandsAndBestShortOne(bool update_score, bool sort_cands);
 };
 
+//==============================================================================
+
+inline HitOnTrack TrackCand::getLastHitOnTrack() const
+{
+   return m_comb_candidate->m_hots[lastHitIdx_].m_hot;
+}
+
+inline int TrackCand::getLastHitIdx() const
+{
+   return m_comb_candidate->m_hots[lastHitIdx_].m_hot.index;
+}
+
+inline int TrackCand::getLastHitLyr() const
+{
+   return m_comb_candidate->m_hots[lastHitIdx_].m_hot.layer;
+}
+
+//------------------------------------------------------------------------------
+
+inline void TrackCand::addHitIdx(int hitIdx, int hitLyr, float chi2)
+{
+  lastHitIdx_ = m_comb_candidate->AddHit({ hitIdx, hitLyr }, lastHitIdx_);
+  if (hitIdx >= 0 || hitIdx == -9)
+  {
+    ++nFoundHits_; chi2_+=chi2;
+    nInsideMinusOneHits_ += nTailMinusOneHits_;
+    nTailMinusOneHits_    = 0;
+  } else {
+    ++nMissingHits_;
+    if (hitIdx == -1) ++nTailMinusOneHits_;
+  }
+}
+
+//==============================================================================
 
 class EventOfCombCandidates
 {
@@ -297,24 +441,20 @@ public:
     m_size      (0)
   {
     Reset(size);
+
+    m_candidates.reserve(256);
   }
 
   void Reset(int new_capacity)
   {
     for (int s = 0; s < m_size; ++s)
     {
-      m_candidates[s].clear();
+      m_candidates[s].Reset();
     }
 
     if (new_capacity > m_capacity)
     {
       m_candidates.resize(new_capacity);
-
-      for (int s = m_capacity; s < new_capacity; ++s)
-      {
-        m_candidates[s].reserve(Config::maxCandsPerSeed); //we should never exceed this
-        m_candidates[s].m_best_short_cand.setCandScore( getScoreWorstPossible() );
-      }
 
       m_capacity = new_capacity;
     }
@@ -328,21 +468,9 @@ public:
   {
     assert (m_size < m_capacity);
 
-    m_candidates[m_size].push_back(seed);
-    m_candidates[m_size].m_state           = CombCandidate::Dormant;
-    m_candidates[m_size].m_last_seed_layer = seed.getLastHitLyr();
-    m_candidates[m_size].m_seed_type = seed.getSeedTypeForRanking();
-    Track &cand = m_candidates[m_size].back();
-    cand.setSeedTypeForRanking(seed.getSeedTypeForRanking());
-    cand.setCandScore         (getScoreCand(seed));
+    m_candidates[m_size].ImportSeed(seed);
+
     ++m_size;
-  }
-
-  void InsertTrack(const Track& track, int seed_index)
-  {
-    assert (seed_index < m_size);
-
-    m_candidates[seed_index].push_back(track);
   }
 };
 

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -1271,7 +1271,7 @@ void MkBuilder::score_tracks(TrackVec& tracks)
   for (auto & track : tracks)
   {
     assignSeedTypeForRanking(track);
-    track.setCandScore(getScoreCand(track));
+    track.setScore(getScoreCand(track));
   }
 }
 
@@ -1317,7 +1317,7 @@ void MkBuilder::find_duplicates(TrackVec& tracks)
 	  if(fracHitsShared < Config::minFracHitsShared) continue;
 	}
 	//Keep track with best score
-	if(track.getCandScore() > track2.getCandScore())
+	if(track.score() > track2.score())
 	{
 	  track2.setDuplicateValue(true);
 	}
@@ -1921,7 +1921,7 @@ void MkBuilder::FindTracksStandard()
               else if (first_short)
               {
                 first_short = false;
-                if (tmp_cands[is][ii].getCandScore() > eoccs[start_seed+is].m_best_short_cand.getCandScore())
+                if (tmp_cands[is][ii].score() > eoccs[start_seed+is].m_best_short_cand.score())
                 {
                   eoccs[start_seed+is].m_best_short_cand = tmp_cands[is][ii];
                 }
@@ -2114,10 +2114,10 @@ void MkBuilder::find_tracks_in_layers(CandCloner &cloner, MkFinder *mkfndr,
 
       for (int i = 0; i < ((int) cc.size()) - 1; ++i)
       {
-        if (cc[i].getCandScore() < cc[i+1].getCandScore())
+        if (cc[i].score() < cc[i+1].score())
         {
           printf("CloneEngine - NOT SORTED: layer=%d, iseed=%d (size=%llu)-- %d : %d smaller than %d : %d\n",
-                 curr_layer, iseed, cc.size(), i, cc[i].getCandScore(), i+1, cc[i+1].getCandScore());
+                 curr_layer, iseed, cc.size(), i, cc[i].score(), i+1, cc[i+1].score());
         }
       }
     }
@@ -2163,7 +2163,7 @@ void MkBuilder::FindTracksFV()
 void MkBuilder::find_tracks_in_layersFV(int start_seed, int end_seed, int region)
 {
 #ifdef INSTANTIATE_FV
-  EventOfCombCandidates  &eoccs             = m_event_of_comb_cands;
+  // QQQQ EventOfCombCandidates  &eoccs             = m_event_of_comb_cands;
   const SteeringParams   &st_par            = m_steering_params[region];
   const TrackerInfo      &trk_info          = Config::TrkInfo;
 
@@ -2181,7 +2181,11 @@ void MkBuilder::find_tracks_in_layersFV(int start_seed, int end_seed, int region
   for (int index = 0; index < nMplx; ++index) {
     for (int offset = 0; offset < MkFinderFv::Seeds; ++offset) {
       dprint("seed " << iseed << " index " << index << " offset " << offset);
-      finders[index].InputTrack(eoccs.m_candidates[iseed][0], iseed, offset, false);
+
+      // QQQQ InputTrack for TrackCand does not exist ... see what to do.
+      //
+      // finders[index].InputTrack(eoccs.m_candidates[iseed][0], iseed, offset, false);
+
       ++iseed;
       iseed = std::min(iseed, end_seed-1);
     }
@@ -2348,6 +2352,10 @@ void MkBuilder::fit_cands_BH(MkFinder *mkfndr, int start_cand, int end_cand, int
 
 void MkBuilder::BackwardFit()
 {
+  // QQQQ - decide what / how to do it
+
+  assert (false && "Currently not supported");
+
   EventOfCombCandidates &eoccs = m_event_of_comb_cands;
 
   tbb::parallel_for_each(m_regions.begin(), m_regions.end(),
@@ -2408,7 +2416,7 @@ void MkBuilder::fit_cands(MkFinder *mkfndr, int start_cand, int end_cand, int re
   redo_fit:
 #endif
     // input tracks
-    mkfndr->BkFitInputTracks(eoccs, icand, end);
+    // QQQQQ mkfndr->BkFitInputTracks(eoccs, icand, end);
 
     // fit tracks back to first layer
     mkfndr->BkFitFitTracks(m_event_of_hits, st_par, end - icand, chi_debug);
@@ -2434,7 +2442,7 @@ void MkBuilder::fit_cands(MkFinder *mkfndr, int start_cand, int end_cand, int re
     }
 #endif
 
-    mkfndr->BkFitOutputTracks(eoccs, icand, end); 
+    // QQQQQ mkfndr->BkFitOutputTracks(eoccs, icand, end);
 
     // printf("Post Final fit for %d - %d\n", icand, end);
     // for (int i = icand; i < end; ++i) { const Track &t = eoccs[i][0];

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -166,9 +166,9 @@ namespace
     return cand1.nFoundHits() > cand2.nFoundHits();
   }
 
-  bool sortCandByScore(const Track & cand1, const Track & cand2)
+  bool sortCandByScore(const TrackCand & cand1, const TrackCand & cand2)
   {
-    return mkfit::sortByScoreCand(cand1,cand2);
+    return mkfit::sortByScoreTrackCand(cand1,cand2);
   }
 }
 
@@ -955,12 +955,12 @@ void MkBuilder::quality_store_tracks(TrackVec& tracks)
     // take the first one!
     if ( ! eoccs.m_candidates[i].empty())
     {
-      const Track &bcand = eoccs.m_candidates[i].front();
+      const TrackCand &bcand = eoccs.m_candidates[i].front();
 
       if (std::isnan(bcand.chi2())) ++chi2_nan_cnt;
       if (bcand.chi2() > 500)       ++chi2_500_cnt;
 
-      tracks.push_back(bcand);
+      tracks.emplace_back( bcand.exportTrack() );
 
 #ifdef DEBUG_BACKWARD_FIT
       printf("CHITRK %d %g %g %g %g %g\n",
@@ -984,7 +984,9 @@ void MkBuilder::quality_process(Track &tkcand, const int itrack, std::map<int,in
   // initialize track extra (input original seed label)
   const auto label = tkcand.label();
   TrackExtra extra(label);
-  
+
+  // track_print(tkcand, "XXX");
+
   // access temp seed trk and set matching seed hits
   const auto & seed = m_event->seedTracks_[itrack];
   extra.findMatchingSeedHits(tkcand, seed, m_event->layerHits_);
@@ -1729,7 +1731,7 @@ int MkBuilder::find_tracks_unroll_candidates(std::vector<std::pair<int,int>> & s
 }
 
 void MkBuilder::find_tracks_handle_missed_layers(MkFinder *mkfndr, const LayerInfo &layer_info,
-                                                 std::vector<std::vector<Track>> &tmp_cands,
+                                                 std::vector<std::vector<TrackCand>> &tmp_cands,
                                                  const std::vector<std::pair<int,int>> &seed_cand_idx,
                                                  const int region, const int start_seed,
                                                  const int itrack, const int end)
@@ -1743,7 +1745,7 @@ void MkBuilder::find_tracks_handle_missed_layers(MkFinder *mkfndr, const LayerIn
   // can really screw you there (need a maxR in candidate?).
   for (int ti = itrack; ti < end; ++ti)
   {
-    Track      &cand = m_event_of_comb_cands.m_candidates[seed_cand_idx[ti].first][seed_cand_idx[ti].second];
+    TrackCand  &cand = m_event_of_comb_cands.m_candidates[seed_cand_idx[ti].first][seed_cand_idx[ti].second];
     WSR_Result &w    = mkfndr->XWsrResult[ti - itrack];
 
     // XXXX-4 Low pT tracks can miss a barrel layer ... and should be stopped
@@ -1821,7 +1823,7 @@ void MkBuilder::FindTracksStandard()
       const int end_seed   = seeds.end();
       const int n_seeds    = end_seed - start_seed;
 
-      std::vector<std::vector<Track>> tmp_cands(n_seeds);
+      std::vector<std::vector<TrackCand>> tmp_cands(n_seeds);
       for (size_t iseed = 0; iseed < tmp_cands.size(); ++iseed)
       {
         tmp_cands[iseed].reserve(2*Config::maxCandsPerSeed);//factor 2 seems reasonable to start with
@@ -1891,30 +1893,20 @@ void MkBuilder::FindTracksStandard()
 
         } //end of vectorized loop
 
-	// clean exceeding candidates per seed
+	// sort the input candidates
         for (int is = 0; is < n_seeds; ++is)
         {
-          dprint("dump seed n " << is << " with input candidates=" << tmp_cands[is].size());
-          //std::sort(tmp_cands[is].begin(), tmp_cands[is].end(), sortCandByHitsChi2);
-          std::sort(tmp_cands[is].begin(), tmp_cands[is].end(), sortCandByScore);
+          dprint("dump seed n " << is << " with N_input_candidates=" << tmp_cands[is].size());
 
-          // MT -- now we just copy as many as we need to below while we take out the -2 cands.
-          // if (tmp_cands[is].size() > static_cast<size_t>(Config::maxCandsPerSeed))
-          // {
-          //   dprint("erase extra candidates" << " tmp_cands[is].size()=" << tmp_cands[is].size()
-          //          << " Config::maxCandsPerSeed=" << Config::maxCandsPerSeed);
-          //   tmp_cands[is].erase(tmp_cands[is].begin() + Config::maxCandsPerSeed,
-          //                       tmp_cands[is].end());
-          // }
-          dprint("dump seed n " << is << " with output candidates=" << tmp_cands[is].size());
+          std::sort(tmp_cands[is].begin(), tmp_cands[is].end(), sortCandByScore);
         }
 
-        // now swap with input candidates
+        // now fill out the output candidates
         for (int is = 0; is < n_seeds; ++is)
         {
           if (tmp_cands[is].size() > 0)
           {
-            eoccs[start_seed+is].resize(0);
+            eoccs[start_seed+is].clear();
 
             // Put good candidates into eoccs, process -2 candidates.
             int  n_placed    = 0;
@@ -1999,7 +1991,7 @@ void MkBuilder::find_tracks_in_layers(CandCloner &cloner, MkFinder *mkfndr,
   seed_cand_idx.reserve       (n_seeds * Config::maxCandsPerSeed);
   seed_cand_update_idx.reserve(n_seeds * Config::maxCandsPerSeed);
 
-  std::vector<std::vector<Track>> extra_cands(n_seeds);
+  std::vector<std::vector<TrackCand>> extra_cands(n_seeds);
   for (int ii = 0; ii < n_seeds; ++ii) extra_cands[ii].reserve(Config::maxCandsPerSeed);
 
   cloner.begin_eta_bin(&eoccs, &seed_cand_update_idx, &extra_cands, start_seed, n_seeds);
@@ -2255,7 +2247,10 @@ void MkBuilder::find_tracks_in_layersFV(int start_seed, int end_seed, int region
     auto& mkf = finders[index];
     auto best = mkf.BestCandidate(offset);
     if (best >= 0) {
-      mkf.OutputTrack(eoccs.m_candidates[iseed], 0, best, true);
+      // QQQ Not implemented
+      // Should, probably, wipe CombCand and re-output
+      // or, just extend from seed hits onwards.
+      // mkf.OutputTrack(eoccs.m_candidates[iseed], 0, best, true);
     }
   }
 #endif

--- a/mkFit/MkBuilder.h
+++ b/mkFit/MkBuilder.h
@@ -186,7 +186,7 @@ public:
                                      int prev_layer, bool pickup_only);
 
   void find_tracks_handle_missed_layers(MkFinder *mkfndr, const LayerInfo &layer_info,
-                                        std::vector<std::vector<Track>> &tmp_cands,
+                                        std::vector<std::vector<TrackCand>> &tmp_cands,
                                         const std::vector<std::pair<int,int>> &seed_cand_idx,
                                         const int region, const int start_seed,
                                         const int itrack, const int end);

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -648,7 +648,7 @@ void MkFinder::FindCandidates(const LayerOfHits &layer_of_hits,
             copy_out(newcand, itrack, iC);
 	    newcand.addHitIdx(XHitArr.At(itrack, hit_cnt, 0), layer_of_hits.layer_id(), chi2);
 	    newcand.setSeedTypeForRanking(SeedType(itrack, 0, 0));
-	    newcand.setCandScore(getScoreCand(newcand));
+	    newcand.setScore(getScoreCand(newcand));
 
 	    dprint("updated track parameters x=" << newcand.parameters()[0] << " y=" << newcand.parameters()[1] << " z=" << newcand.parameters()[2] << " pt=" << 1./newcand.parameters()[3]);
 
@@ -686,7 +686,7 @@ void MkFinder::FindCandidates(const LayerOfHits &layer_of_hits,
     copy_out(newcand, itrack, iP);
     newcand.addHitIdx(fake_hit_idx, layer_of_hits.layer_id(), 0.);
     newcand.setSeedTypeForRanking(SeedType(itrack, 0, 0));
-    newcand.setCandScore(getScoreCand(newcand));
+    newcand.setScore(getScoreCand(newcand));
     tmp_candidates[SeedIdx(itrack, 0, 0) - offset].emplace_back(newcand);
   }
 }
@@ -884,6 +884,8 @@ void MkFinder::BkFitInputTracks(TrackVec& cands, int beg, int end)
 
 //------------------------------------------------------------------------------
 
+/* QQQQ - out until further notice
+
 void MkFinder::BkFitInputTracks(EventOfCombCandidates& eocss, int beg, int end)
 {
   // XXXX Can cause trouble if per-seed vectors get scattered beyond 2GB (or maybe 8).
@@ -912,7 +914,7 @@ void MkFinder::BkFitInputTracks(EventOfCombCandidates& eocss, int beg, int end)
 
   Err[iC].Scale(100.0f);
 }
-
+*/
 
 void MkFinder::BkFitOutputTracks(TrackVec& cands, int beg, int end)
 {
@@ -929,10 +931,12 @@ void MkFinder::BkFitOutputTracks(TrackVec& cands, int beg, int end)
       trk.setChi2(Chi2(itrack, 0, 0));
       if(!(std::isnan(trk.chi2())))
       {
-	trk.setCandScore(getScoreCand(trk));
+	trk.setScore(getScoreCand(trk));
       }
     }
 }
+
+/* QQQQ - out until further notice
 
 void MkFinder::BkFitOutputTracks(EventOfCombCandidates& eocss, int beg, int end)
 {
@@ -949,10 +953,12 @@ void MkFinder::BkFitOutputTracks(EventOfCombCandidates& eocss, int beg, int end)
     trk.setChi2(Chi2(itrack, 0, 0));
     if(!(std::isnan(trk.chi2())))
     {
-      trk.setCandScore(getScoreCand(trk));
+      trk.setScore(getScoreCand(trk));
     }
   }
 }
+*/
+
 
 } // end namespace mkfit
 //------------------------------------------------------------------------------

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -63,17 +63,17 @@ void MkFinder::InputTracksAndHitIdx(const std::vector<CombCandidate>     & track
 
   for (int i = beg, imp = 0; i < end; ++i, ++imp)
   {
-    const Track &trk = tracks[idxs[i].first][idxs[i].second];
+    const TrackCand &trk = tracks[idxs[i].first][idxs[i].second];
 
     copy_in(trk, imp, iI);
-    
+
     SeedType(imp, 0, 0) = tracks[idxs[i].first].m_seed_type;
     SeedIdx(imp, 0, 0) = idxs[i].first;
     CandIdx(imp, 0, 0) = idxs[i].second;
   }
 }
 
-void MkFinder::InputTracksAndHitIdx(const std::vector<CombCandidate>                       & tracks,
+void MkFinder::InputTracksAndHitIdx(const std::vector<CombCandidate>             & tracks,
                                     const std::vector<std::pair<int,IdxChi2List>>& idxs,
                                     int beg, int end, bool inputProp)
 {
@@ -86,7 +86,7 @@ void MkFinder::InputTracksAndHitIdx(const std::vector<CombCandidate>            
 
   for (int i = beg, imp = 0; i < end; ++i, ++imp)
   {
-    const Track &trk = tracks[idxs[i].first][idxs[i].second.trkIdx];
+    const TrackCand &trk = tracks[idxs[i].first][idxs[i].second.trkIdx];
 
     copy_in(trk, imp, iI);
 
@@ -556,7 +556,7 @@ void MkFinder::AddBestHit(const LayerOfHits &layer_of_hits, const int N_proc,
 //==============================================================================
 
 void MkFinder::FindCandidates(const LayerOfHits &layer_of_hits,
-                              std::vector<std::vector<Track>>& tmp_candidates,
+                              std::vector<std::vector<TrackCand>>& tmp_candidates,
                               const int offset, const int N_proc,
                               const FindingFoos &fnd_foos)
 {
@@ -642,8 +642,9 @@ void MkFinder::FindCandidates(const LayerOfHits &layer_of_hits,
 	  if (chi2 < Config::chi2Cut)
 	  {
 	    dprint("chi2 cut passed, creating new candidate");
-	    //create a new candidate and fill the reccands_tmp vector
-	    Track newcand;
+	    // Create a new candidate and fill the tmp_candidates output vector.
+            // QQQ only instantiate if it will pass, be better than N_best
+	    TrackCand newcand;
             copy_out(newcand, itrack, iC);
 	    newcand.addHitIdx(XHitArr.At(itrack, hit_cnt, 0), layer_of_hits.layer_id(), chi2);
 	    newcand.setSeedTypeForRanking(SeedType(itrack, 0, 0));
@@ -663,19 +664,14 @@ void MkFinder::FindCandidates(const LayerOfHits &layer_of_hits,
   //fixme: please vectorize me...
   for (int itrack = 0; itrack < N_proc; ++itrack)
   {
-    // XXXXMT HACK ... put in original track if a layer was missed completely.
-    // Can/should be done earlier? It must be - we can be propagated to outer
-    // space by now for low pt, low eta tracks.
-    // XXXX-1 - This is now done before, in MkBuilder(), with original candidate, before propagation.
+    // Cands that miss the layer are stashed away in MkBuilder(), before propagation,
+    // and then merged back afterwards.
     if (XWsrResult[itrack].m_wsr == WSR_Outside)
     {
-      // Track newcand;
-      // copy_out(newcand, itrack, iP);
-      // tmp_candidates[SeedIdx(itrack, 0, 0) - offset].emplace_back(newcand);
       continue;
     }
 
-    int fake_hit_idx = num_invalid_hits(itrack,true) < Config::maxHolesPerCand ? -1 : -2;
+    int fake_hit_idx = num_all_minus_one_hits(itrack) < Config::maxHolesPerCand ? -1 : -2;
 
     if (XWsrResult[itrack].m_wsr == WSR_Edge)
     {
@@ -685,7 +681,8 @@ void MkFinder::FindCandidates(const LayerOfHits &layer_of_hits,
 
     dprint("ADD FAKE HIT FOR TRACK #" << itrack << " withinBounds=" << (fake_hit_idx != -3) << " r=" << std::hypot(Par[iP](itrack,0,0), Par[iP](itrack,1,0)));
 
-    Track newcand;
+    // QQQ as above, only create and add if score better
+    TrackCand newcand;
     copy_out(newcand, itrack, iP);
     newcand.addHitIdx(fake_hit_idx, layer_of_hits.layer_id(), 0.);
     newcand.setSeedTypeForRanking(SeedType(itrack, 0, 0));
@@ -721,7 +718,6 @@ void MkFinder::FindCandidatesCloneEngine(const LayerOfHits &layer_of_hits, CandC
       }
     }
   }
-  // XXXX MT FIXME: use masks to filter out SlurpIns
 
   dprintf("FindCandidatesCloneEngine max hits to process=%d\n", maxSize);
 
@@ -756,16 +752,16 @@ void MkFinder::FindCandidatesCloneEngine(const LayerOfHits &layer_of_hits, CandC
         if (chi2 < Config::chi2Cut)
         {
           IdxChi2List tmpList;
-          tmpList.trkIdx = CandIdx(itrack, 0, 0);
-          tmpList.hitIdx = XHitArr.At(itrack, hit_cnt, 0);
-          tmpList.nhits  = NFoundHits(itrack,0,0) + 1;
-          tmpList.nholes  = num_invalid_hits(itrack,true);
+          tmpList.trkIdx   = CandIdx(itrack, 0, 0);
+          tmpList.hitIdx   = XHitArr.At(itrack, hit_cnt, 0);
+          tmpList.nhits    = NFoundHits(itrack,0,0) + 1;
+          tmpList.nholes   = num_all_minus_one_hits(itrack);
           tmpList.seedtype = SeedType(itrack, 0, 0);
-          tmpList.pt = std::abs(1.0f/Par[iP].At(itrack,3,0));
-          tmpList.chi2   = Chi2(itrack, 0, 0) + chi2;
-          tmpList.score  = getScoreStruct(tmpList);
+          tmpList.pt       = std::abs(1.0f/Par[iP].At(itrack,3,0));
+          tmpList.chi2     = Chi2(itrack, 0, 0) + chi2;
+          tmpList.score    = getScoreStruct(tmpList);
           cloner.add_cand(SeedIdx(itrack, 0, 0) - offset, tmpList);
-          // hitsToAdd[SeedIdx(itrack, 0, 0)-offset].push_back(tmpList);
+
           dprint("  adding hit with hit_cnt=" << hit_cnt << " for trkIdx=" << tmpList.trkIdx << " orig Seed=" << Label(itrack, 0, 0));
         }
       }
@@ -776,16 +772,16 @@ void MkFinder::FindCandidatesCloneEngine(const LayerOfHits &layer_of_hits, CandC
   //now add invalid hit
   for (int itrack = 0; itrack < N_proc; ++itrack)
   {
-    dprint("num_invalid_hits(" << itrack << ")=" << num_invalid_hits(itrack,true));
+    dprint("num_all_minus_one_hits(" << itrack << ")=" << num_all_minus_one_hits(itrack));
 
+    // Cands that miss the layer are stashed away in MkBuilder(), before propagation,
+    // and then merged back afterwards.
     if (XWsrResult[itrack].m_wsr == WSR_Outside)
     {
-      // fake_hit_idx = -4;
-      dprint("track missed layer, not adding a clone with a missing hit");
-      continue; // handled outside, keep previous parameters
+      continue;
     }
 
-    int fake_hit_idx = num_invalid_hits(itrack,true) < Config::maxHolesPerCand ? -1 : -2;
+    int fake_hit_idx = num_all_minus_one_hits(itrack) < Config::maxHolesPerCand ? -1 : -2;
 
     if (XWsrResult[itrack].m_wsr == WSR_Edge)
     {
@@ -793,14 +789,14 @@ void MkFinder::FindCandidatesCloneEngine(const LayerOfHits &layer_of_hits, CandC
     }
 
     IdxChi2List tmpList;
-    tmpList.trkIdx = CandIdx(itrack, 0, 0);
-    tmpList.hitIdx = fake_hit_idx;
-    tmpList.nhits  = NFoundHits(itrack,0,0);
-    tmpList.nholes  = num_invalid_hits(itrack,false);
+    tmpList.trkIdx   = CandIdx(itrack, 0, 0);
+    tmpList.hitIdx   = fake_hit_idx;
+    tmpList.nhits    = NFoundHits(itrack,0,0);
+    tmpList.nholes   = num_inside_minus_one_hits(itrack);
     tmpList.seedtype = SeedType(itrack, 0, 0);
-    tmpList.pt = std::abs(1.0f/Par[iP].At(itrack,3,0));
-    tmpList.chi2   = Chi2(itrack, 0, 0);
-    tmpList.score  = getScoreStruct(tmpList);
+    tmpList.pt       = std::abs(1.0f/Par[iP].At(itrack,3,0));
+    tmpList.chi2     = Chi2(itrack, 0, 0);
+    tmpList.score    = getScoreStruct(tmpList);
     cloner.add_cand(SeedIdx(itrack, 0, 0) - offset, tmpList);
     dprint("adding invalid hit " << fake_hit_idx);
   }
@@ -816,9 +812,7 @@ void MkFinder::UpdateWithLastHit(const LayerOfHits &layer_of_hits, int N_proc,
 {
   for (int i = 0; i < N_proc; ++i)
   {
-    const HitOnTrack &hot = HoTArrs[i][ NHits[i] - 1];
-
-    if (hot.index < 0) continue;
+    const HitOnTrack &hot = LastHoT[i];
 
     const Hit &hit = layer_of_hits.GetHit(hot.index);
 
@@ -828,33 +822,6 @@ void MkFinder::UpdateWithLastHit(const LayerOfHits &layer_of_hits, int N_proc,
 
   (*fnd_foos.m_update_param_foo)(Err[iP], Par[iP], Chg, msErr, msPar,
                                  Err[iC], Par[iC], N_proc, Config::finding_intra_layer_pflags);
-
-  //now that we have moved propagation at the end of the sequence we lost the handle of
-  //using the propagated parameters instead of the updated for the missing hit case.
-  //so we need to replace by hand the updated with the propagated
-  //there may be a better way to restore this...
-
-  for (int i = 0; i < N_proc; ++i)
-  {
-    if (HoTArrs[i][ NHits[i] - 1].index < 0)
-    {
-      printf("MkFinder::UpdateWithLastHit hit with negative index %d ... i=%d, N_proc=%d.\n",
-             HoTArrs[i][ NHits[i] - 1].index, i, N_proc);
-      assert (false && "This should not happen now that CandCloner builds a true update list.");
-      /*
-      float tmp[21];
-      Err[iP].CopyOut(i, tmp);
-      Err[iC].CopyIn (i, tmp);
-      Par[iP].CopyOut(i, tmp);
-      Par[iC].CopyIn (i, tmp);
-
-      if (HoTArrs[i][ NHits[i] - 1].index == -4)
-      {
-        --NHits[i];
-      }
-      */
-    }
-  }
 }
 
 
@@ -869,13 +836,9 @@ void MkFinder::CopyOutParErr(std::vector<CombCandidate>& seed_cand_vec,
 
   for (int i = 0; i < N_proc; ++i)
   {
-    //create a new candidate and fill the cands_for_next_lay vector
-    Track &cand = seed_cand_vec[SeedIdx(i, 0, 0)][CandIdx(i, 0, 0)];
+    TrackCand &cand = seed_cand_vec[SeedIdx(i, 0, 0)][CandIdx(i, 0, 0)];
 
-    // clone-engine update can remove the last hit if invalid (no chi2 change)
-    cand.setNTotalHits(NHits[i]);
-
-    //set the track state to the updated parameters
+    // Set the track state to the updated parameters
     Err[iO].CopyOut(i, cand.errors_nc().Array());
     Par[iO].CopyOut(i, cand.parameters_nc().Array());
 
@@ -978,7 +941,7 @@ void MkFinder::BkFitOutputTracks(EventOfCombCandidates& eocss, int beg, int end)
   int itrack = 0;
   for (int i = beg; i < end; ++i, ++itrack)
   {
-    Track &trk = eocss[i][0];
+    TrackCand &trk = eocss[i][0];
 
     Err[iP].CopyOut(itrack, trk.errors_nc().Array());
     Par[iP].CopyOut(itrack, trk.parameters_nc().Array());

--- a/mkFit/MkFinder.h
+++ b/mkFit/MkFinder.h
@@ -157,8 +157,10 @@ public:
 
   void BkFitInputTracks (TrackVec& cands, int beg, int end);
   void BkFitOutputTracks(TrackVec& cands, int beg, int end);
-  void BkFitInputTracks (EventOfCombCandidates& eocss, int beg, int end);
-  void BkFitOutputTracks(EventOfCombCandidates& eocss, int beg, int end);
+
+  // QQQQQ - out until further notice
+  // void BkFitInputTracks (EventOfCombCandidates& eocss, int beg, int end);
+  // void BkFitOutputTracks(EventOfCombCandidates& eocss, int beg, int end);
 
   void BkFitFitTracks(const EventOfHits& eventofhits, const SteeringParams& st_par,
                       const int N_proc, bool chiDebug = false);
@@ -192,8 +194,7 @@ private:
     trk.setChi2  (Chi2 (mslot, 0, 0));
     trk.setLabel (Label(mslot, 0, 0));
 
-    trk.setNTotalHits(NHits     (mslot, 0, 0));
-    trk.setNFoundHits(NFoundHits(mslot, 0, 0));
+    trk.resizeHits(NHits(mslot, 0, 0), NFoundHits(mslot, 0, 0));
     std::copy(HoTArrs[mslot], & HoTArrs[mslot][NHits(mslot, 0, 0)], trk.BeginHitsOnTrack_nc());
   }
 

--- a/mkFit/MkFinder.h
+++ b/mkFit/MkFinder.h
@@ -7,7 +7,8 @@
 
 //#include "Event.h"
 
-//#include "HitStructures.h"
+// Needed for TrackCand
+#include "HitStructures.h"
 
 namespace mkfit {
 
@@ -67,6 +68,15 @@ public:
   MPlexQI    SeedIdx; // seed index in local thread (for bookkeeping at thread level)
   MPlexQI    CandIdx; // candidate index for the given seed (for bookkeeping of clone engine)
 
+  // Additions / substitutions for TrackCand copy_in/out()
+  MPlexQI    NMissingHits;   // sub: NHits, sort of
+  MPlexQI    NInsideMinusOneHits;  // sub: before we copied all hit idcs and had a loop counting them
+  MPlexQI    NTailMinusOneHits;  // sub: before we copied all hit idcs and had a loop counting them
+  MPlexQI    LastHitCcIndex; // add: index of last hit in CombCand hit tree
+  HitOnTrack LastHoT[NN];
+  CombCandidate *CombCand[NN];
+  // const TrackCand *TrkCand[NN]; // hmmh, could get all data through this guy ... but scattered
+
   // Hit indices into LayerOfHits to explore.
   WSR_Result  XWsrResult[NN]; // Could also merge it with XHitSize. Or use smaller arrays.
   MPlexQI     XHitSize;
@@ -123,7 +133,7 @@ public:
   //----------------------------------------------------------------------------
 
   void FindCandidates(const LayerOfHits &layer_of_hits,
-                      std::vector<std::vector<Track>>& tmp_candidates,
+                      std::vector<std::vector<TrackCand>>& tmp_candidates,
 		      const int offset, const int N_proc,
                       const FindingFoos &fnd_foos);
 
@@ -187,6 +197,45 @@ private:
     std::copy(HoTArrs[mslot], & HoTArrs[mslot][NHits(mslot, 0, 0)], trk.BeginHitsOnTrack_nc());
   }
 
+  void copy_in(const TrackCand& trk, const int mslot, const int tslot)
+  {
+    Err[tslot].CopyIn(mslot, trk.errors().Array());
+    Par[tslot].CopyIn(mslot, trk.parameters().Array());
+
+    Chg  (mslot, 0, 0) = trk.charge();
+    Chi2 (mslot, 0, 0) = trk.chi2();
+    Label(mslot, 0, 0) = trk.label();
+
+    LastHitCcIndex(mslot, 0, 0) = trk.lastCcIndex();
+    NFoundHits    (mslot, 0, 0) = trk.nFoundHits();
+    NMissingHits  (mslot, 0, 0) = trk.nMissingHits();
+
+    NInsideMinusOneHits(mslot, 0, 0) = trk.nInsideMinusOneHits();
+    NTailMinusOneHits  (mslot, 0, 0) = trk.nTailMinusOneHits();
+
+    LastHoT[mslot]  = trk.getLastHitOnTrack();
+    CombCand[mslot] = trk.combCandidate();
+  }
+
+  void copy_out(TrackCand& trk, const int mslot, const int tslot) const
+  {
+    Err[tslot].CopyOut(mslot, trk.errors_nc().Array());
+    Par[tslot].CopyOut(mslot, trk.parameters_nc().Array());
+
+    trk.setCharge(Chg  (mslot, 0, 0));
+    trk.setChi2  (Chi2 (mslot, 0, 0));
+    trk.setLabel (Label(mslot, 0, 0));
+
+    trk.setLastCcIndex (LastHitCcIndex(mslot, 0, 0));
+    trk.setNFoundHits  (NFoundHits    (mslot, 0, 0));
+    trk.setNMissingHits(NMissingHits  (mslot, 0, 0));
+
+    trk.setNInsideMinusOneHits(NInsideMinusOneHits(mslot, 0, 0));
+    trk.setNTailMinusOneHits  (NTailMinusOneHits  (mslot, 0, 0));
+
+    trk.setCombCandidate( CombCand[mslot] );
+  }
+
   void add_hit(const int mslot, int index, int layer)
   {
     int &n_tot_hits = NHits(mslot, 0, 0);
@@ -218,15 +267,14 @@ private:
     }
   }
 
-  int num_invalid_hits(const int mslot, bool insideValid = false) const
+  int num_all_minus_one_hits(const int mslot) const
   {
-    int n = 0;
-    for (int i = NHits(mslot, 0, 0)-1; i >= 0; --i)
-      {
-	if (HoTArrs[mslot][i].index >= 0) insideValid = true;
-	if (insideValid && HoTArrs[mslot][i].index == -1) ++n;
-      }
-    return n;
+    return NInsideMinusOneHits(mslot, 0, 0) + NTailMinusOneHits(mslot, 0, 0);
+  }
+
+  int num_inside_minus_one_hits(const int mslot) const
+  {
+    return NInsideMinusOneHits(mslot, 0, 0);
   }
 };
 

--- a/mkFit/MkFinderFV.h
+++ b/mkFit/MkFinderFV.h
@@ -166,8 +166,7 @@ private:
     trk.setChi2  (Chi2 (mslot, 0, 0));
     trk.setLabel (Label(mslot, 0, 0));
 
-    trk.setNTotalHits(NHits     (mslot, 0, 0));
-    trk.setNFoundHits(NFoundHits(mslot, 0, 0));
+    trk.resizeHits(NHits(mslot, 0, 0), NFoundHits(mslot, 0, 0));
     std::copy(HoTArrs[mslot], & HoTArrs[mslot][NHits(mslot, 0, 0)], trk.BeginHitsOnTrack_nc());
   }
 

--- a/mkFit/MkFitter.cc
+++ b/mkFit/MkFitter.cc
@@ -592,7 +592,10 @@ void MkFitter::OutputFittedTracksAndHitIdx(std::vector<Track>& tracks, int beg, 
     tracks[i].setChi2(Chi2(itrack, 0, 0));
     tracks[i].setLabel(Label(itrack, 0, 0));
 
+    // QQQQ Could do resize and std::copy, as in MkFinder::copy_out(), but
+    // we do not know the correct N_found_hits.
     tracks[i].resetHits();
+    tracks[i].reserveHits(Nhits);
     for (int hi = 0; hi < Nhits; ++hi)
     {
       tracks[i].addHitIdx(HoTArr[hi](itrack, 0, 0), 0.);

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -285,14 +285,17 @@ double runBuildingTestPlexStandard(Event& ev, MkBuilder& builder)
   // now do backwards fit... do we want to time this section?
   if (Config::backwardFit)
   {
-    builder.BackwardFit();
+    // QQQQ Using the TrackVec version until we home in on THE backward fit etc.
+    // builder.BackwardFit();
+    builder.BackwardFitBH();
 
     check_nan_n_silly_bkfit(ev);
 
-    if (Config::sim_val || Config::cmssw_val || Config::cmssw_export)
-    {
-      builder.quality_store_tracks(ev.fitTracks_);
-    }
+    // QQQQ already done by BackwardFitBH()
+    // if (Config::sim_val || Config::cmssw_val || Config::cmssw_export)
+    // {
+    //   builder.quality_store_tracks(ev.fitTracks_);
+    // }
   }
 
   builder.handle_duplicates();
@@ -348,14 +351,17 @@ double runBuildingTestPlexCloneEngine(Event& ev, MkBuilder& builder)
   // now do backwards fit... do we want to time this section?
   if (Config::backwardFit)
   {
-    builder.BackwardFit();
+    // QQQQ Using the TrackVec version until we home in on THE backward fit etc.
+    // builder.BackwardFit();
+    builder.BackwardFitBH();
 
     check_nan_n_silly_bkfit(ev);
 
-    if (Config::sim_val || Config::cmssw_val || Config::cmssw_export)
-    {
-      builder.quality_store_tracks(ev.fitTracks_);
-    }
+   // QQQQ already done by BackwardFitBH()
+   // if (Config::sim_val || Config::cmssw_val || Config::cmssw_export)
+   //  {
+   //    builder.quality_store_tracks(ev.fitTracks_);
+   //  }
   }
 
   builder.handle_duplicates();

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -495,10 +495,13 @@ void test_standard()
                t_best[0], t_best[1], t_best[2], t_best[3], t_best[4]);
       }
 
-      // not protected by a mutex, may be inacccurate for multiple events in flight;
-      // probably should convert to a scaled long so can use std::atomic<Integral>
-      for (int i = 0; i < NT; ++i) t_sum[i] += t_best[i];
-      if (evt > 0) for (int i = 0; i < NT; ++i) t_skip[i] += t_best[i];
+      {
+        static std::mutex sum_up_lock;
+        std::lock_guard<std::mutex> locker(sum_up_lock);
+
+        for (int i = 0; i < NT; ++i) t_sum[i] += t_best[i];
+        if (evt > 0) for (int i = 0; i < NT; ++i) t_skip[i] += t_best[i];
+      }
     }
   }, tbb::simple_partitioner());
 

--- a/mkFit/mt-notes.txt
+++ b/mkFit/mt-notes.txt
@@ -1,3 +1,36 @@
+
+With GC's cluster info etc ... testing
+--------------------------------------
+
+./writeMemoryFile --input ~slava77/data-buffer/CMSSW_10_4_0_patch1-tkNtuple/pass-925bb57/initialStep/default/10muPt0p2to10HS/trackingNtuple.root --output ../../mu-hs.bin --clean-sim-tracks --apply-ccc --write-rec-tracks &
+
+./writeMemoryFile --input ~slava77/data-buffer/CMSSW_10_4_0_patch1-tkNtuple/pass-925bb57/initialStep/default/11024.0_TTbar_13/AVE_70_BX01_25ns/trackingNtuple.root --output ../../pu70-ccc-hs.bin --clean-sim-tracks --apply-ccc --write-rec-tracks &
+
+./writeMemoryFile --input ~slava77/data-buffer/CMSSW_10_4_0_patch1-tkNtuple/pass-925bb57/initialStep/default/11024.0_TTbar_13/AVE_50_BX01_25ns/trackingNtuple.root --output ../../pu50-ccc-hs.bin --clean-sim-tracks --apply-ccc --write-rec-tracks &
+
+Data-format change: Hit gets module id, cluster info, Track now uses std::vector<HitOnTrack>
+--------------------------------------------------------------------------------------------
+
+* phi1 setup / running notes
+
+.  /cvmfs/cms.cern.ch/slc7_amd64_gcc630/lcg/root/6.12.07-gnimlf2/etc/profile.d/init.sh
+.  /cvmfs/cms.cern.ch/slc7_amd64_gcc630/external/tbb/2018_U1-cms/etc/profile.d/init.sh
+export TBB_PREFIX=$TBB_ROOT
+
+./writeMemoryFile --input root://redirector//store/user/slava77/CMSSW_9_1_0_pre1-tkNtuple/run1000/2017/pass-c93773a/initialStep/10muPt0p5to10HS//trackingNtuple.root --output ../../mu-hs.bin --clean-sim-tracks --apply-ccc --write-rec-tracks &
+
+./writeMemoryFile --input root://redirector//store/user/slava77/CMSSW_9_1_0_pre1-tkNtuple/run1000/2017/pass-c93773a/initialStep/PU70/10224.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2017PU_GenSimFullINPUT+DigiFullPU_2017PU+RecoFullPU_2017PU+HARVESTFullPU_2017PU/trackingNtuple.root --output ../../pu70-ccc.bin --clean-sim-tracks --apply-ccc --write-rec-tracks &
+
+./writeMemoryFile --input root://redirector//store/user/slava77/CMSSW_9_1_0_pre1-tkNtuple/run1000/2017/pass-c93773a/initialStep/PU70HS/10224.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2017PU_GenSimFullINPUT+DigiFullPU_2017PU+RecoFullPU_2017PU+HARVESTFullPU_2017PU/trackingNtuple.root --output ../../pu70-ccc-hs.bin --clean-sim-tracks --apply-ccc --write-rec-tracks &
+
+
+.  /cvmfs/cms.cern.ch/slc7_amd64_gcc630/external/gdb/7.12.1-omkpbe2/etc/profile.d/init.sh
+.  /cvmfs/cms.cern.ch/slc7_amd64_gcc630/external/valgrind/3.13.0-omkpbe/etc/profile.d/init.sh
+
+mkFit/mkFit --cmssw-n2seeds --input-file /data2/mu-hs.bin --build-std
+mkFit/mkFit --cmssw-n2seeds --input-file /data2/pu70-ccc-hs.bin --build-std --quality-val --num-events 10
+
+
 TrackBase, TrackCand, storage of cand hits into a tree structure
 ----------------------------------------------------------------
 

--- a/mkFit/mt-notes.txt
+++ b/mkFit/mt-notes.txt
@@ -1,4 +1,159 @@
 
+Sim 2018 PU70 sample - hit, module infos
+----------------------------------------
+
+Average number of seeds per event 828.942505
+Average number of hits in layer   0 = 3073.32
+Average number of hits in layer   1 = 2615.13
+Average number of hits in layer   2 = 2277.22
+Average number of hits in layer   3 = 1917.71
+Average number of hits in layer   4 = 4214.65
+Average number of hits in layer   5 = 4349.80
+Average number of hits in layer   6 = 3720.44
+Average number of hits in layer   7 = 3737.94
+Average number of hits in layer   8 = 3085.48
+Average number of hits in layer   9 = 2640.19
+Average number of hits in layer  10 = 3470.67
+Average number of hits in layer  11 = 3450.70
+Average number of hits in layer  12 = 2955.59
+Average number of hits in layer  13 = 3003.03
+Average number of hits in layer  14 = 2380.01
+Average number of hits in layer  15 = 1955.55
+Average number of hits in layer  16 = 1700.98
+Average number of hits in layer  17 = 1360.74
+Average number of hits in layer  18 = 1198.10
+Average number of hits in layer  19 = 1276.75
+Average number of hits in layer  20 = 1361.93
+Average number of hits in layer  21 = 1032.49
+Average number of hits in layer  22 =  768.76
+Average number of hits in layer  23 = 1130.75
+Average number of hits in layer  24 =  748.53
+Average number of hits in layer  25 = 1187.02
+Average number of hits in layer  26 =  849.00
+Average number of hits in layer  27 = 2272.04
+Average number of hits in layer  28 = 1071.64
+Average number of hits in layer  29 = 2412.70
+Average number of hits in layer  30 = 1157.40
+Average number of hits in layer  31 = 2486.16
+Average number of hits in layer  32 = 1201.94
+Average number of hits in layer  33 = 2076.90
+Average number of hits in layer  34 =  750.31
+Average number of hits in layer  35 = 2154.58
+Average number of hits in layer  36 =  762.48
+Average number of hits in layer  37 = 2209.81
+Average number of hits in layer  38 =  775.21
+Average number of hits in layer  39 = 1770.90
+Average number of hits in layer  40 =  349.86
+Average number of hits in layer  41 = 1854.49
+Average number of hits in layer  42 =  389.69
+Average number of hits in layer  43 = 1464.36
+Average number of hits in layer  44 =  403.46
+Average number of hits in layer  45 = 1235.84
+Average number of hits in layer  46 = 1362.54
+Average number of hits in layer  47 = 1412.89
+Average number of hits in layer  48 = 1016.37
+Average number of hits in layer  49 =  726.22
+Average number of hits in layer  50 = 1029.12
+Average number of hits in layer  51 =  623.23
+Average number of hits in layer  52 = 1189.20
+Average number of hits in layer  53 =  854.48
+Average number of hits in layer  54 = 2289.76
+Average number of hits in layer  55 = 1105.33
+Average number of hits in layer  56 = 2312.55
+Average number of hits in layer  57 = 1117.81
+Average number of hits in layer  58 = 2497.48
+Average number of hits in layer  59 = 1208.42
+Average number of hits in layer  60 = 2105.25
+Average number of hits in layer  61 =  755.48
+Average number of hits in layer  62 = 2159.37
+Average number of hits in layer  63 =  758.59
+Average number of hits in layer  64 = 2195.77
+Average number of hits in layer  65 =  745.96
+Average number of hits in layer  66 = 1810.17
+Average number of hits in layer  67 =  330.47
+Average number of hits in layer  68 = 1909.99
+Average number of hits in layer  69 =  388.32
+Average number of hits in layer  70 = 1473.86
+Average number of hits in layer  71 =  406.15
+Out of 1239532103 hits, 196376076 failed the cut
+
+================================================================
+=== Max module id for 72 layers
+================================================================
+Layer 0 : 92
+Layer 1 : 209
+Layer 2 : 336
+Layer 3 : 488
+Layer 4 : 306
+Layer 5 : 313
+Layer 6 : 409
+Layer 7 : 407
+Layer 8 : 494
+Layer 9 : 576
+Layer10 : 498
+Layer11 : 498
+Layer12 : 567
+Layer13 : 567
+Layer14 : 624
+Layer15 : 672
+Layer16 : 779
+Layer17 : 881
+Layer18 : 108
+Layer19 : 109
+Layer20 : 110
+Layer21 : 85
+Layer22 : 48
+Layer23 : 86
+Layer24 : 44
+Layer25 : 87
+Layer26 : 48
+Layer27 : 311
+Layer28 : 82
+Layer29 : 319
+Layer30 : 88
+Layer31 : 316
+Layer32 : 88
+Layer33 : 294
+Layer34 : 63
+Layer35 : 294
+Layer36 : 63
+Layer37 : 288
+Layer38 : 61
+Layer39 : 258
+Layer40 : 37
+Layer41 : 261
+Layer42 : 40
+Layer43 : 225
+Layer44 : 40
+Layer45 : 111
+Layer46 : 110
+Layer47 : 111
+Layer48 : 84
+Layer49 : 45
+Layer50 : 81
+Layer51 : 37
+Layer52 : 88
+Layer53 : 48
+Layer54 : 319
+Layer55 : 88
+Layer56 : 312
+Layer57 : 86
+Layer58 : 318
+Layer59 : 88
+Layer60 : 296
+Layer61 : 64
+Layer62 : 295
+Layer63 : 63
+Layer64 : 291
+Layer65 : 60
+Layer66 : 261
+Layer67 : 35
+Layer68 : 267
+Layer69 : 40
+Layer70 : 227
+Layer71 : 40
+
+
 With GC's cluster info etc ... testing
 --------------------------------------
 

--- a/mkFit/mt-notes.txt
+++ b/mkFit/mt-notes.txt
@@ -1,3 +1,43 @@
+TrackBase, TrackCand, storage of cand hits into a tree structure
+----------------------------------------------------------------
+
+The shittiest part of the problem seems to be how one handles backward fit and
+pickup of overlap hits. OK, and then getting rid of outliers.
+
+It almost seems like TrackFinalCand class would be needed where one would be
+able to add and remove hits relatively easily. Like having a list but this is horrible.
+
+On the other hand, once outward processing is done for a seed, a single
+candidate is selected and therefore we can in principle screw up the hit history.
+- Will we ever consider more than one Cand from a single seed?
+- Have we finally checked if abs diag errors could be used to stop a cand (or at least
+  reduce its score)?
+  - For shortish tracks, how suspect should one be of the final couple of hits?
+
+? HitStore interface to Track -- could this make Track indepenent of how hits are actually stored?
+Several implementations + with/without cache (like N_holes).
+
+? Filling / retrieving data from Matriplexes. MkFinder CopyIn/Out interfaces
+... are they overdone, ie, should the guy the fills them up store extra data
+elsewhere instead of putting it into Matriplex members of MkFinder?
+
+------------------------------------------------------------------------
+
+- Keep Track as IO object.
+
+- Move all you need to move to TrackBase (need to keep memory layout of Track
+  intact so all members before State need to be moved, too).
+
+------------------------------------------------------------------------
+
+CE and STD give identical track results as devel.
+For 5k PU70 evs, 64 thr, 16 EIF, avx_512 (on phi3, best run out of 3):
+ - CE  15% faster build,  3% better wall time
+ - STD 25% faster build, 10% better wall time
+
+
+================================================================================
+
 Using non-sorted hits from external hit-vector ...
 ----------------------------------------------
 

--- a/tkNtuple/DictsLinkDef.h
+++ b/tkNtuple/DictsLinkDef.h
@@ -3,11 +3,16 @@
 
 #ifdef __CINT__
 #pragma link C++ class vector<vector<int> >+ ;
+#pragma link C++ class vector<vector<unsigned int> >+ ;
 #pragma link C++ class vector<vector<float> >+ ;
 #ifdef G__VECTOR_HAS_CLASS_ITERATOR
 #pragma link C++ operators vector<vector<int> >::iterator;
 #pragma link C++ operators vector<vector<int> >::const_iterator;
 #pragma link C++ operators vector<vector<int> >::reverse_iterator;
+
+#pragma link C++ operators vector<vector<unsigned int> >::iterator;
+#pragma link C++ operators vector<vector<unsigned int> >::const_iterator;
+#pragma link C++ operators vector<vector<unsigned int> >::reverse_iterator;
 
 #pragma link C++ operators vector<vector<float> >::iterator;
 #pragma link C++ operators vector<vector<float> >::const_iterator;

--- a/val_scripts/validation-cmssw-benchmarks.sh
+++ b/val_scripts/validation-cmssw-benchmarks.sh
@@ -6,7 +6,7 @@
 
 suite=${1:-"forPR"} # which set of benchmarks to run: full, forPR, forConf
 style=${2:-"--mtv-like-val"} # option --mtv-like-val
-inputBin=${3:-"91XPU70CCC"}
+inputBin=${3:-"104XPU50CCC"}
 
 ###################
 ## Configuration ##
@@ -18,16 +18,17 @@ source xeon_scripts/init-env.sh
 ## Common file setup
 case ${inputBin} in 
 "91XPU70CCC")
-        echo "Inputs from 2017 initialStep PU 70 with CCC"
+        echo "Inputs from 2017 initialStep PU 70 with CCC -- DO NOT WORK ANYMORE"
+        exit 1
         dir=/data2/slava77/samples/2017/pass-c93773a/initialStep
         subdir=PU70HS/10224.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2017PU_GenSimFullINPUT+DigiFullPU_2017PU+RecoFullPU_2017PU+HARVESTFullPU_2017PU
         file=memoryFile.fv3.clean.writeAll.CCC1620.recT.082418-25daeda.bin
         ;;
-"104XPU70CCC")
-        echo "Inputs from 2018 initialStep/default PU 70 with CCC"
-        dir=/data2/slava77/samples/2018/pass-e072c1a/initialStep/default
-        subdir=11024.0_TTbar_13/AVE_70_BX01_25ns
-        file=memoryFile.fv3.clean.writeAll.CCC1620.recT.190423-19a1bc3.bin
+"104XPU50CCC")
+        echo "Inputs from 2018 initialStep/default PU 50 with CCC"
+        dir=/data2
+        subdir=
+        file=pu50-ccc-hs.bin
         ;;
 *)
         echo "INPUT BIN IS UNKNOWN"
@@ -83,7 +84,7 @@ function doVal()
     local bExe="${exe} ${vO} --build-${bO}"
     
     echo "${oBase}: ${vN} [nTH:${maxth}, nVU:${maxvu}int, nEV:${maxev}]"
-    ${bExe} >& log_${oBase}_NVU${maxvu}int_NTH${maxth}_NEV${maxev}_${vN}.txt
+    ${bExe} >& log_${oBase}_NVU${maxvu}int_NTH${maxth}_NEV${maxev}_${vN}.txt || (echo Crashed; exit 2)
     
     # hadd output files for this test, then move to temporary directory
     hadd -O valtree.root valtree_*.root
@@ -100,7 +101,7 @@ function plotVal()
     local pO=${4}
 
     echo "Computing observables for: ${base} ${bN} ${pN}"
-    root -b -q -l plotting/runValidation.C\(\"_${base}_${bN}_${pN}\",${pO}\)
+    root -b -q -l plotting/runValidation.C\(\"_${base}_${bN}_${pN}\",${pO}\) || (echo Crashed; exit 3)
 }
 
 ########################

--- a/xeon_scripts/benchmark-cmssw-ttbar-fulldet-build.sh
+++ b/xeon_scripts/benchmark-cmssw-ttbar-fulldet-build.sh
@@ -21,7 +21,7 @@ source xeon_scripts/init-env.sh
 if [[ "${ben_arch}" == "SNB" ]]
 then
     mOpt="-j 12"
-    dir=/data2/nfsmic/slava77/samples
+    dir=/data2
     maxth=24
     maxvu=8
     declare -a nths=("1" "2" "4" "6" "8" "12" "16" "20" "24")
@@ -30,7 +30,7 @@ then
 elif [[ "${ben_arch}" == "KNL" ]]
 then
     mOpt="-j 64 AVX_512:=1"
-    dir=/data1/work/slava77/samples
+    dir=/data2
     maxth=256
     maxvu=16
     declare -a nths=("1" "2" "4" "8" "16" "32" "64" "96" "128" "160" "192" "224" "256")
@@ -39,7 +39,7 @@ then
 elif [[ "${ben_arch}" == "SKL-SP" ]]
 then
     mOpt="-j 32 AVX_512:=1"
-    dir=/data2/slava77/samples
+    dir=/data2
     maxth=64
     maxvu=16
     declare -a nths=("1" "2" "4" "8" "16" "32" "48" "64")
@@ -69,8 +69,8 @@ else
 fi
 
 ## Common file setup
-subdir=2017/pass-c93773a/initialStep/PU70HS/10224.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2017PU_GenSimFullINPUT+DigiFullPU_2017PU+RecoFullPU_2017PU+HARVESTFullPU_2017PU
-file=memoryFile.fv3.clean.writeAll.CCC1620.recT.082418-25daeda.bin
+subdir=
+file=pu50-ccc-hs.bin
 nevents=20
 
 ## Common executable setup

--- a/xeon_scripts/common-variables.sh
+++ b/xeon_scripts/common-variables.sh
@@ -6,7 +6,7 @@ useARCH=${2:-0} # which computer cluster to run on. 0=phi3, 1=lnx, 2= phi3+lnx, 
 lnxuser=${3:-${USER}} #username for lnx computers
 
 # samples
-export sample=CMSSW_TTbar_PU70
+export sample=CMSSW_TTbar_PU50
 
 # Validation architecture
 export val_arch=SKL-SP


### PR DESCRIPTION
* Track is broken into TrackBase and Track
* TrackCand is used during track finding, implementing common hit-on-track storage for all candidates stemming from the same seed
* Track now uses std::vector<HitOnTrack> for hit storage
* Hit has been extended with bit-packed module-id-in-layer, charge_per_cm, and span_X/Y
* Bin-file-writer has been modified accordingly
* This requires a new bin file version (now at 4, samples have to be recreated, some are available at phi1 and phi3 in /data2)
