### PR TITLE
Allow enabling duplicate removal from CMSSW

### DIFF
--- a/ConfigWrapper.cc
+++ b/ConfigWrapper.cc
@@ -34,6 +34,10 @@ namespace mkfit {
       fillZRgridME();
     }
 
+    void setRemoveDuplicates(bool removeDuplicates) {
+      Config::removeDuplicates = removeDuplicates;
+    }
+
     void setNTotalLayers(int nTotalLayers) {
       Config::nTotalLayers = nTotalLayers;
     }

--- a/ConfigWrapper.h
+++ b/ConfigWrapper.h
@@ -20,6 +20,7 @@ namespace mkfit {
     };
 
     void initializeForCMSSW(SeedCleaningOpts seedClean, BackwardFit backfit, bool silent);
+    void setRemoveDuplicates(bool removeDuplicates);
 
     void setNTotalLayers(int nTotalLayers);
   }


### PR DESCRIPTION
This PR adds the ability to turn on the duplicate removal from CMSSW.

The corresponding update on CMSSW side is in my 10_4_0_patch1 branch https://github.com/makortel/cmssw/tree/mkfit_1040p1 (along with backported evolution of https://github.com/cms-sw/cmssw/pull/27895).