### PR TITLE
Optimize duplicate removal

### DIFF
--- a/Config.cc
+++ b/Config.cc
@@ -87,9 +87,9 @@ namespace Config
 
   bool  removeDuplicates = false;
   bool  useHitsForDuplicates = true;
-  float maxdPhi = 0.1;
-  float maxdPt  = 0.05;
-  float maxdEta = 0.2;
+  float maxdPhi = 0.4;
+  float maxdPt  = 0.7;
+  float maxdEta = 0.1;
   float minFracHitsShared = 0.75;
 
   bool mtvLikeValidation = false;

--- a/Config.cc
+++ b/Config.cc
@@ -89,8 +89,9 @@ namespace Config
   bool  useHitsForDuplicates = true;
   float maxdPhi = 0.4;
   float maxdPt  = 0.7;
-  float maxdEta = 0.1;
+  float maxdEta = 0.05;
   float minFracHitsShared = 0.75;
+  float maxdRSquared = 0.000001; //corresponds to maxdR of 0.001
 
   bool mtvLikeValidation = false;
   bool mtvRequireSeeds = false;

--- a/Config.h
+++ b/Config.h
@@ -328,6 +328,7 @@ namespace Config
   extern float maxdPt;
   extern float maxdEta;
   extern float minFracHitsShared;
+  extern float maxdRSquared;
 
   // config on seed cleaning
   constexpr int minNHits_seedclean = 4;

--- a/Track.h
+++ b/Track.h
@@ -437,6 +437,7 @@ public:
     return mcHitID;
   }
 
+  const std::vector<HitOnTrack>* getHitsOnTrackVector() const { return &hitsOnTrk_;}
   const HitOnTrack* getHitsOnTrackArray() const { return hitsOnTrk_.data(); }
   const HitOnTrack* BeginHitsOnTrack()    const { return hitsOnTrk_.data(); }
   const HitOnTrack* EndHitsOnTrack()      const { return hitsOnTrk_.data() + (lastHitIdx_ + 1); }

--- a/Track.h
+++ b/Track.h
@@ -437,7 +437,6 @@ public:
     return mcHitID;
   }
 
-  const std::vector<HitOnTrack>* getHitsOnTrackVector() const { return &hitsOnTrk_;}
   const HitOnTrack* getHitsOnTrackArray() const { return hitsOnTrk_.data(); }
   const HitOnTrack* BeginHitsOnTrack()    const { return hitsOnTrk_.data(); }
   const HitOnTrack* EndHitsOnTrack()      const { return hitsOnTrk_.data() + (lastHitIdx_ + 1); }

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -1304,15 +1304,18 @@ void MkBuilder::find_duplicates(TrackVec& tracks)
 	  float numHitsShared = 0;
 	  for (int ihit = 0; ihit < track.nTotalHits(); ihit++)
 	  {
-	    vecOfHits.push_back(track.getHitIdx(ihit));
+	    if(track.getHitIdx(ihit)>=0) vecOfHits.push_back(track.getHitIdx(ihit));
 	  }
 	  for (int ihit2 = 0; ihit2 < track2.nTotalHits(); ihit2++)
 	  {
-	    std::vector<int>::iterator it;
-	    it = std::find(vecOfHits.begin(), vecOfHits.end(),track2.getHitIdx(ihit2) );
-	    if (it != vecOfHits.end()) numHitsShared++;
+	    if(track2.getHitIdx(ihit2) >= 0)
+	    {
+	      std::vector<int>::iterator it;
+	      it = std::find(vecOfHits.begin(), vecOfHits.end(),track2.getHitIdx(ihit2) );
+	      if (it != vecOfHits.end()) numHitsShared++;
+	    }
 	  }
-	  float fracHitsShared = (track.nTotalHits() < track2.nTotalHits()) ? numHitsShared/track.nTotalHits() : numHitsShared/track2.nTotalHits();
+	  float fracHitsShared = numHitsShared/std::min(track.nFoundHits(),track2.nFoundHits());
 	  //Only remove one of the tracks if they share at least 90% of the hits (denominator is the shorter track)
 	  if(fracHitsShared < Config::minFracHitsShared) continue;
 	}

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -1302,18 +1302,18 @@ void MkBuilder::find_duplicates(TrackVec& tracks)
       {
         //Keep track with best score
         if(track.score() > track2.score())  track2.setDuplicateValue(true);
-	else track.setDuplicateValue(true);
-	continue;
+        else track.setDuplicateValue(true);
+        continue;
       }
       else
       {
-	maxpt = std::max(pt1,track2.pT());
-	if(maxpt ==0) continue;
+        maxpt = std::max(pt1,track2.pT());
+        if(maxpt ==0) continue;
 
         if(std::abs(track2.pT() - pt1)/maxpt < Config::maxdPt)
         {
-	  if(Config::useHitsForDuplicates)
-	  {
+          if(Config::useHitsForDuplicates)
+          {
 	    float numHitsShared = 0;
 	    for (int ihit2 = 0; ihit2 < track2.nTotalHits(); ihit2++)
 	    {
@@ -1334,7 +1334,7 @@ void MkBuilder::find_duplicates(TrackVec& tracks)
 	  //Keep track with best score
 	  if(track.score() > track2.score())  track2.setDuplicateValue(true);
 	  else track.setDuplicateValue(true);	  
-	} //end of if dPt
+        } //end of if dPt
       } //end of else
     } //end of loop over track2
   } //end of loop over track1 

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -1279,29 +1279,43 @@ void MkBuilder::score_tracks(TrackVec& tracks)
 void MkBuilder::find_duplicates(TrackVec& tracks)
 {
   const auto ntracks = tracks.size();
+  float eta1, phi1, pt1, deta, dphi, maxpt, dr2;
   for (auto itrack = 0U; itrack < ntracks-1; itrack++)
   {
     auto & track = tracks[itrack];
-    float eta1 = track.momEta();
-    float phi1 = track.momPhi();
-    float pt1  = track.pT();
+    eta1 = track.momEta();
+    phi1 = track.momPhi();
+    pt1  = track.pT();
     for (auto jtrack = itrack+1; jtrack < ntracks; jtrack++)
     {
       auto & track2 = tracks[jtrack];
       if(track.label() == track2.label()) continue;
-      float eta2 = track2.momEta();
-      float phi2 = track2.momPhi();
-      float pt2  = track2.pT();
-      float dphi = squashPhiMinimal(phi1-phi2);
-      float deta = std::abs(eta2 - eta1);
-      float maxpt = std::max(pt1,pt2);
-      if(maxpt ==0) continue;
-      if(dphi < Config::maxdPhi && std::abs(pt2 - pt1)/maxpt < Config::maxdPt && deta < Config::maxdEta)
+     
+      deta = std::abs(track2.momEta() - eta1);
+      if(deta > Config::maxdEta) continue;
+
+      dphi = std::abs(squashPhiMinimal(phi1-track2.momPhi()));
+      if(dphi > Config::maxdPhi) continue;
+
+      dr2 = dphi*dphi + deta*deta;
+      if(dr2 < Config::maxdRSquared)
       {
-	if(Config::useHitsForDuplicates)
-	{
-	  float numHitsShared = 0;
-	  for (int ihit2 = 0; ihit2 < track2.nTotalHits(); ihit2++)
+        //Keep track with best score
+        if(track.score() > track2.score())  track2.setDuplicateValue(true);
+	else track.setDuplicateValue(true);
+	continue;
+      }
+      else
+      {
+	maxpt = std::max(pt1,track2.pT());
+	if(maxpt ==0) continue;
+
+        if(std::abs(track2.pT() - pt1)/maxpt < Config::maxdPt)
+        {
+	  if(Config::useHitsForDuplicates)
+	  {
+	    float numHitsShared = 0;
+	    for (int ihit2 = 0; ihit2 < track2.nTotalHits(); ihit2++)
 	    {
 	      int hitidx2 = track2.getHitIdx(ihit2);
 	      int hitlyr2 = track2.getHitLyr(ihit2);
@@ -1313,22 +1327,17 @@ void MkBuilder::find_duplicates(TrackVec& tracks)
 	      }
 	    }
 
-	  float fracHitsShared = numHitsShared/std::min(track.nFoundHits(),track2.nFoundHits());
-	  //Only remove one of the tracks if they share at least X% of the hits (denominator is the shorter track)
-	  if(fracHitsShared < Config::minFracHitsShared) continue;
-	}
-	//Keep track with best score
-	if(track.score() > track2.score())
-	{
-	  track2.setDuplicateValue(true);
-	}
-	else
-	{
-	  track.setDuplicateValue(true);
-	}
-      }
-    }
-  }
+	    float fracHitsShared = numHitsShared/std::min(track.nFoundHits(),track2.nFoundHits());
+	    //Only remove one of the tracks if they share at least X% of the hits (denominator is the shorter track)
+	    if(fracHitsShared < Config::minFracHitsShared) continue;
+	  }
+	  //Keep track with best score
+	  if(track.score() > track2.score())  track2.setDuplicateValue(true);
+	  else track.setDuplicateValue(true);	  
+	} //end of if dPt
+      } //end of else
+    } //end of loop over track2
+  } //end of loop over track1 
 }
 
 void MkBuilder::remove_duplicates(TrackVec & tracks)

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -1300,23 +1300,22 @@ void MkBuilder::find_duplicates(TrackVec& tracks)
       {
 	if(Config::useHitsForDuplicates)
 	{
-	  std::vector<int> vecOfHits;
 	  float numHitsShared = 0;
-	  for (int ihit = 0; ihit < track.nTotalHits(); ihit++)
-	  {
-	    if(track.getHitIdx(ihit)>=0) vecOfHits.push_back(track.getHitIdx(ihit));
-	  }
+	  const std::vector<HitOnTrack> *hots = track.getHitsOnTrackVector();
 	  for (int ihit2 = 0; ihit2 < track2.nTotalHits(); ihit2++)
-	  {
-	    if(track2.getHitIdx(ihit2) >= 0)
 	    {
-	      std::vector<int>::iterator it;
-	      it = std::find(vecOfHits.begin(), vecOfHits.end(),track2.getHitIdx(ihit2) );
-	      if (it != vecOfHits.end()) numHitsShared++;
+	      int hitidx2 = track2.getHitIdx(ihit2);
+	      int hitlyr2 = track2.getHitLyr(ihit2);
+	      if(hitidx2 >=0)
+	      {
+		auto it = std::find_if (hots->begin(), hots->end(),[&hitidx2,&hitlyr2](const HitOnTrack& element){
+		    return (element.index == hitidx2 && element.layer == hitlyr2);});
+		if (it != hots->end()) numHitsShared++;
+	      }
 	    }
-	  }
+
 	  float fracHitsShared = numHitsShared/std::min(track.nFoundHits(),track2.nFoundHits());
-	  //Only remove one of the tracks if they share at least 90% of the hits (denominator is the shorter track)
+	  //Only remove one of the tracks if they share at least X% of the hits (denominator is the shorter track)
 	  if(fracHitsShared < Config::minFracHitsShared) continue;
 	}
 	//Keep track with best score

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -1301,16 +1301,15 @@ void MkBuilder::find_duplicates(TrackVec& tracks)
 	if(Config::useHitsForDuplicates)
 	{
 	  float numHitsShared = 0;
-	  const std::vector<HitOnTrack> *hots = track.getHitsOnTrackVector();
 	  for (int ihit2 = 0; ihit2 < track2.nTotalHits(); ihit2++)
 	    {
 	      int hitidx2 = track2.getHitIdx(ihit2);
 	      int hitlyr2 = track2.getHitLyr(ihit2);
 	      if(hitidx2 >=0)
 	      {
-		auto it = std::find_if (hots->begin(), hots->end(),[&hitidx2,&hitlyr2](const HitOnTrack& element){
+		auto it = std::find_if (track.BeginHitsOnTrack(), track.EndHitsOnTrack(),[&hitidx2,&hitlyr2](const HitOnTrack& element){
 		    return (element.index == hitidx2 && element.layer == hitlyr2);});
-		if (it != hots->end()) numHitsShared++;
+		if (it != track.EndHitsOnTrack() ) numHitsShared++;
 	      }
 	    }
 

--- a/plotting/StackValidation.cpp
+++ b/plotting/StackValidation.cpp
@@ -104,7 +104,7 @@ void StackValidation::MakeRatioStacks(const TString & trk)
 	  
 	  graph->Draw(b>0?"PZ SAME":"APZ");
 
-	  if (!rate.rate.Contains("ineff",TString::kExact)) graph->GetYaxis()->SetRangeUser(0.0,1.05);
+	  if (!rate.rate.Contains("ineff",TString::kExact) && !rate.rate.Contains("dr",TString::kExact)) graph->GetYaxis()->SetRangeUser(0.0,1.05);
 	  else graph->GetYaxis()->SetRangeUser(0.0,0.25);
 	  
 	  leg->AddEntry(graph,build.label.Data(),"LEP");
@@ -145,7 +145,7 @@ void StackValidation::MakeRatioStacks(const TString & trk)
 	    auto & graph = graphs[b];
 	    graph->GetXaxis()->SetRangeUser(0.01,graph->GetXaxis()->GetBinUpEdge(graph->GetXaxis()->GetNbins()));
 
-	    if (!rate.rate.Contains("ineff",TString::kExact)) graph->GetYaxis()->SetRangeUser(0.0,1.05);
+	    if (!rate.rate.Contains("ineff",TString::kExact) && !rate.rate.Contains("dr",TString::kExact)) graph->GetYaxis()->SetRangeUser(0.0,1.05);
 	    else graph->GetYaxis()->SetRangeUser(0.0,0.25);
 
 	    graph->GetXaxis()->SetTitle(xtitle);


### PR DESCRIPTION
This PR has several changes that improve the timing, physics performance, and plotting of the duplicate removal. The new plots can be found [here](http://areinsvo.web.cern.ch/areinsvo/MkFit/DuplicateRemoval/TimingStudies/findIf/).
Compare these to the results from the current head of devel [here](http://areinsvo.web.cern.ch/areinsvo/MkFit/DuplicateRemoval/TimingStudies/develRangeChange/).

Note that to check the effect on timing for the duplicate removal, you need to look at the MEIF plots.

For full details, including other things I tried to speed up the hit comparison for the duplicate removal, see the slides [here](https://indico.cern.ch/event/845065/contributions/3548442/attachments/1945220/3228411/DupRemoval_Nov2019.pdf), which I will share at our meeting later today.