### PR TITLE
writer update for hltIter0; introduce val and valMT1 suites for the val script

### DIFF
--- a/plotting/Common.hh
+++ b/plotting/Common.hh
@@ -217,7 +217,7 @@ namespace
   }
 };
 
-enum SuiteEnum {full, forPR, forConf};
+enum SuiteEnum {full, forPR, forConf, val};
 
 namespace 
 {
@@ -227,6 +227,7 @@ namespace
     if      (suite.Contains("full"))    SUITE = full;
     else if (suite.Contains("forPR"))   SUITE = forPR;
     else if (suite.Contains("forConf")) SUITE = forConf;
+    else if (suite.Contains("val"))     SUITE = val;
     else 
     {
       std::cerr << suite.Data() << " is not an allowed validation suite! Exiting... " << std::endl;
@@ -287,6 +288,18 @@ namespace
     {
       builds.emplace_back(buildsMap["CE"]);
       builds.back().label = "mkFit"; // change label in legend for conference
+    }
+    else if (SUITE == val)
+    {
+      if (isBenchmark)
+      {
+        std::cout<<"INFO: val mode has an empty set for isBenchmark" << std::endl;
+      }
+      else
+      {
+	builds.emplace_back(buildsMap["STD"]);
+	builds.emplace_back(buildsMap["CE"]);
+      }
     }
     else
     {

--- a/plotting/PlotValidation.cpp
+++ b/plotting/PlotValidation.cpp
@@ -1016,7 +1016,7 @@ void PlotValidation::SetupStyle()
 void PlotValidation::SetupBins()
 {
   // pt bins
-  PlotValidation::SetupVariableBins("0 0.25 0.5 0.75 1 1.25 1.5 1.75 2 2.5 3 3.5 4 4.5 5 5 6 7 8 9 10 15 20 25 30 40 50 100",fPtBins); 
+  PlotValidation::SetupVariableBins("0 0.25 0.5 0.75 1 1.25 1.5 1.75 2 2.5 3 3.5 4 4.5 5 5 6 7 8 9 10 15 20 25 30 40 50 100 200 500 1000",fPtBins);
   
   // eta bins
   PlotValidation::SetupFixedBins(60,-3,3,fEtaBins);

--- a/tkNtuple/WriteMemoryFile.cc
+++ b/tkNtuple/WriteMemoryFile.cc
@@ -40,7 +40,44 @@ enum class TrackAlgorithm {
   jetCoreRegionalStep = 11,
   conversionStep = 12,
   muonSeededStepInOut = 13,
-  muonSeededStepOutIn = 14
+  muonSeededStepOutIn = 14,
+  outInEcalSeededConv = 15,
+  inOutEcalSeededConv = 16,
+  nuclInter = 17,
+  standAloneMuon = 18,
+  globalMuon = 19,
+  cosmicStandAloneMuon = 20,
+  cosmicGlobalMuon = 21,
+  // Phase1
+  highPtTripletStep = 22,
+  lowPtQuadStep = 23,
+  detachedQuadStep = 24,
+  reservedForUpgrades1 = 25,
+  reservedForUpgrades2 = 26,
+  bTagGhostTracks = 27,
+  beamhalo = 28,
+  gsf = 29,
+  // HLT algo name
+  hltPixel = 30,
+  // steps used by PF
+  hltIter0 = 31,
+  hltIter1 = 32,
+  hltIter2 = 33,
+  hltIter3 = 34,
+  hltIter4 = 35,
+  // steps used by all other objects @HLT
+  hltIterX = 36,
+  // steps used by HI muon regional iterative tracking
+  hiRegitMuInitialStep = 37,
+  hiRegitMuLowPtTripletStep = 38,
+  hiRegitMuPixelPairStep = 39,
+  hiRegitMuDetachedTripletStep = 40,
+  hiRegitMuMixedTripletStep = 41,
+  hiRegitMuPixelLessStep = 42,
+  hiRegitMuTobTecStep = 43,
+  hiRegitMuMuonSeededStepInOut = 44,
+  hiRegitMuMuonSeededStepOutIn = 45,
+  algoSize = 46
 };
 
 typedef std::list<std::string> lStr_t;
@@ -744,7 +781,9 @@ int main(int argc, char *argv[])
     vector<Track> &seedTracks_ = EE.seedTracks_;
     vector<vector<int> > pixHitSeedIdx(pix_lay->size());
     for (unsigned int is = 0; is<see_q->size(); ++is) {
-      if (TrackAlgorithm(see_algo->at(is))!=TrackAlgorithm::initialStep) continue;//select seed in acceptance
+      auto isAlgo = TrackAlgorithm(see_algo->at(is));
+      if (isAlgo != TrackAlgorithm::initialStep 
+          && isAlgo != TrackAlgorithm::hltIter0 ) continue;//select seed in acceptance
       //if (see_pt->at(is)<0.5 || fabs(see_eta->at(is))>0.8) continue;//select seed in acceptance
       SVector3 pos = SVector3(see_stateTrajGlbX->at(is),see_stateTrajGlbY->at(is),see_stateTrajGlbZ->at(is));
       SVector3 mom = SVector3(see_stateTrajGlbPx->at(is),see_stateTrajGlbPy->at(is),see_stateTrajGlbPz->at(is));
@@ -775,7 +814,7 @@ int main(int argc, char *argv[])
       Track track(state, 0, seedSimIdx[is], 0, nullptr);
       auto const& shTypes = see_hitType->at(is);
       auto const& shIdxs = see_hitIdx->at(is);
-      if (! (TrackAlgorithm(see_algo->at(is))== TrackAlgorithm::initialStep
+      if (! ( (isAlgo == TrackAlgorithm::initialStep || isAlgo == TrackAlgorithm::hltIter0)
 	     && std::count(shTypes.begin(), shTypes.end(), int(HitType::Pixel))>=3)) continue;//check algo and nhits
       for (unsigned int ip=0; ip<shTypes.size(); ip++) {
 	unsigned int ipix = shIdxs[ip];
@@ -792,7 +831,8 @@ int main(int argc, char *argv[])
     vector<vector<int> > strHitRecIdx(str_lay->size());
     vector<vector<int> > gluHitRecIdx(glu_lay->size());
     for (unsigned int ir = 0; ir<trk_q->size(); ++ir) {
-      if ((trk_algoMask->at(ir) & (1 << int(TrackAlgorithm::initialStep))) == 0){//check the origin; redundant for initialStep ntuples
+      //check the origin; redundant for initialStep ntuples
+      if ((trk_algoMask->at(ir) & ( (1 << int(TrackAlgorithm::initialStep )) | (1 << int(TrackAlgorithm::hltIter0 )) )) == 0){
 	if (verbosity > 1){
 	  std::cout<<"track "<<ir<<" failed algo selection for "<< int(TrackAlgorithm::initialStep) <<": mask "<<trk_algoMask->at(ir)
 		   <<" origAlgo "<<trk_originalAlgo->at(ir)<<" algo "<<trk_algo->at(ir)

--- a/val_scripts/validation-cmssw-benchmarks.sh
+++ b/val_scripts/validation-cmssw-benchmarks.sh
@@ -33,12 +33,34 @@ case ${inputBin} in
         file=pu50-ccc-hs.bin
         ;;
 "104X10muHLT3CCC")
-        echo "Inputs from 2018 10mu large pt range using HLT iter0 seeds as triplets with CCC"
-        dir=/data1/work/slava77/analysis/CMSSW_10_4_0_patch1-tkNtuple/pass-f2bb882
+        echo "Inputs from 2018 10mu large pt range using HLT iter0 seeds as triplets with CCC (phi3)"
+        dir=/data2/slava77/samples/2018/pass-2eaa1f7
         subdir=hltIter0/default/triplet/10muPt0p2to1000HS
-        file=memoryFile.fv4.clean.writeAll.CCC1620.recT.200115-0a18240.bin
+        file=memoryFile.fv4.clean.writeAll.CCC1620.recT.200122-fcff8a8.bin
         nevents=10000
         sample=CMSSW_10mu_HLT3
+        ;;
+"104X10muHLT4CCC")
+        echo "Inputs from 2018 10mu large pt range using HLT iter0 seeds as quadruplets with CCC (phi3)"
+        dir=/data2/slava77/samples/2018/pass-2eaa1f7
+        subdir=hltIter0/default/quadruplet/10muPt0p2to1000HS
+        file=memoryFile.fv4.clean.writeAll.CCC1620.recT.200122-fcff8a8.bin
+        nevents=10000
+        sample=CMSSW_10mu_HLT4
+        ;;
+"104XPU50HLT3CCC")
+        echo "Inputs from 2018 ttbar PU50 using HLT iter0 seeds as triplets with CCC (phi3)"
+        dir=/data2/slava77/samples/2018/pass-2eaa1f7
+        subdir=hltIter0/default/triplet/11024.0_TTbar_13/AVE_50_BX01_25ns
+        file=memoryFile.fv4.clean.writeAll.CCC1620.recT.200122-fcff8a8.bin
+        sample=CMSSW_TTbar_PU50_HLT3
+        ;;
+"104XPU50HLT4CCC")
+        echo "Inputs from 2018 ttbar PU50 using HLT iter0 seeds as quadruplets with CCC (phi3)"
+        dir=/data2/slava77/samples/2018/pass-2eaa1f7
+        subdir=hltIter0/default/quadruplet/11024.0_TTbar_13/AVE_50_BX01_25ns
+        file=memoryFile.fv4.clean.writeAll.CCC1620.recT.200122-fcff8a8.bin
+        sample=CMSSW_TTbar_PU50_HLT4
         ;;
 *)
         echo "INPUT BIN IS UNKNOWN"

--- a/val_scripts/validation-cmssw-benchmarks.sh
+++ b/val_scripts/validation-cmssw-benchmarks.sh
@@ -32,6 +32,14 @@ case ${inputBin} in
         subdir=
         file=pu50-ccc-hs.bin
         ;;
+"104X10muCCC")
+        echo "Inputs from 2018 10mu large pt range using the offline initialStep seeds with CCC (phi3)"
+        dir=/data2/slava77/samples/2018/pass-925bb57
+        subdir=initialStep/default/10muPt0p2to1000HS
+        file=memoryFile.fv4.clean.writeAll.CCC1620.recT.191108-c41a0f2.bin
+        nevents=10000
+        sample=CMSSW_10mu
+        ;;
 "104X10muHLT3CCC")
         echo "Inputs from 2018 10mu large pt range using HLT iter0 seeds as triplets with CCC (phi3)"
         dir=/data2/slava77/samples/2018/pass-2eaa1f7

--- a/val_scripts/validation-cmssw-benchmarks.sh
+++ b/val_scripts/validation-cmssw-benchmarks.sh
@@ -100,7 +100,7 @@ function doVal()
     echo "${oBase}: ${vN} [nTH:${maxth}, nVU:${maxvu}int, nEV:${maxev}]"
     ${bExe} >& log_${oBase}_NVU${maxvu}int_NTH${maxth}_NEV${maxev}_${vN}.txt || (echo "Crashed on CMD: "${bExe}; exit 2)
     
-    if (( ${maxth} > 1 ))
+    if (( ${maxev} > 1 ))
     then
         # hadd output files from different threads for this test, then move to temporary directory
         hadd -O valtree.root valtree_*.root

--- a/val_scripts/validation-cmssw-benchmarks.sh
+++ b/val_scripts/validation-cmssw-benchmarks.sh
@@ -15,6 +15,8 @@ inputBin=${3:-"104XPU50CCC"}
 source xeon_scripts/common-variables.sh ${suite}
 source xeon_scripts/init-env.sh
 
+nevents=500
+
 ## Common file setup
 case ${inputBin} in 
 "91XPU70CCC")
@@ -30,12 +32,18 @@ case ${inputBin} in
         subdir=
         file=pu50-ccc-hs.bin
         ;;
+"104X10muHLT3CCC")
+        echo "Inputs from 2018 10mu large pt range using HLT iter0 seeds as triplets with CCC"
+        dir=/data1/work/slava77/analysis/CMSSW_10_4_0_patch1-tkNtuple/pass-f2bb882
+        subdir=hltIter0/default/triplet/10muPt0p2to1000HS
+        file=memoryFile.fv4.clean.writeAll.CCC1620.recT.200115-0a18240.bin
+        nevents=10000
+        ;;
 *)
         echo "INPUT BIN IS UNKNOWN"
         exit 12
         ;;
 esac
-nevents=500
 
 ## Common executable setup
 maxth=64

--- a/xeon_scripts/common-variables.sh
+++ b/xeon_scripts/common-variables.sh
@@ -60,6 +60,10 @@ elif [[ "${suite}" == "forConf" ]]
 then
     declare -a ben_builds=(CE)
     declare -a val_builds=(CE)
+elif [[ "${suite}" == "val" || "${suite}" == "valMT1" ]]
+then
+    declare -a ben_builds=()
+    declare -a val_builds=(STD CE)
 else
     echo ${suite} "is not a valid benchmarking suite option! Exiting..."
     exit


### PR DESCRIPTION
- extend support for hltIter0 in the WriteMemoryFile
- validation/benchmarks updates for validation-only option
    - add val and valMT1 to do just the validation run (no benchmarking); the valMT1 option is running the jobs in 1-thread mode. I introduced valMT1 to circumvent random crashes observed in my tests on phi2 when running validation multithreaded
    - add a hook for inputBin option 104X10muHLT3CCC to run on 10mu gun events (the file in the hook is still temporary and will be updated once I rerun on a full sample)
    - extend the higher pt range in the plots vs pt to 1TeV (added bins edges at 200, 500, and 1000)
