### PR TITLE
Fix negative values in seed covariance matrices

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -393,8 +393,8 @@ namespace Config
 
   constexpr bool nan_n_silly_check_seeds      = true;
   constexpr bool nan_n_silly_print_bad_seeds  = false;
-  constexpr bool nan_n_silly_fixup_bad_seeds  = false;
-  constexpr bool nan_n_silly_remove_bad_seeds = true;
+  constexpr bool nan_n_silly_fixup_bad_seeds  = true;
+  constexpr bool nan_n_silly_remove_bad_seeds = false;
 
   constexpr bool nan_n_silly_check_cands_every_layer     = false;
   constexpr bool nan_n_silly_print_bad_cands_every_layer = false;


### PR DESCRIPTION
This PR improves the efficiency of building high pt (> 100 GeV) tracks by manually fixing negative values in the covariance matrix of the seeds. The benchmark plots for the ttbar PU 50 sample can be found here: http://areinsvo.web.cern.ch/areinsvo/MkFit/Benchmarks/PR250. The changes are minimal, since most tracks are < 100 GeV. 

For the high pt 10muon sample with offline seeds (found at /data2/slava77/samples/2018/pass-925bb57/initialStep/default/10muPt0p2to1000HS/memoryFile.fv4.clean.writeAll.CCC1620.recT.191108-c41a0f2.bin), the efficiency jumped from 81.5 to 99.8%, at the expense of an increase in duplicate rate (11.4% before, 18.4% after). See plots [before](http://areinsvo.web.cern.ch/areinsvo/MkFit/EffHighPt_Jan2020/testHighPt10mu_master/SIMVAL_MTV_SEED/) and after [after](http://areinsvo.web.cern.ch/areinsvo/MkFit/EffHighPt_Jan2020/testHighPt10mu_fixupBadSeeds/SIMVAL_MTV_SEED/). 

For the high pt 10 muon sample with HLT triplet seeds (found at /data2/slava77/samples/2018/pass-f2bb882/hltIter0/default/triplet/10muPt0p2to1000HS/memoryFile.fv4.clean.writeAll.CCC1620.recT.200115-0a18240.bin), the efficiency jumped from 76.7% [before](http://areinsvo.web.cern.ch/areinsvo/MkFit/EffHighPt_Jan2020/testHighPt10muHLT_master/SIMVAL_MTV_SEED) to 99.6% [after](http://areinsvo.web.cern.ch/areinsvo/MkFit/EffHighPt_Jan2020/testHighPt10muHLT_fixupBadSeeds/SIMVAL_MTV_SEED/).