### PR TITLE
Fix charge flip

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -393,8 +393,8 @@ namespace Config
 
   constexpr bool nan_n_silly_check_seeds      = true;
   constexpr bool nan_n_silly_print_bad_seeds  = false;
-  constexpr bool nan_n_silly_fixup_bad_seeds  = false;
-  constexpr bool nan_n_silly_remove_bad_seeds = true;
+  constexpr bool nan_n_silly_fixup_bad_seeds  = true;
+  constexpr bool nan_n_silly_remove_bad_seeds = false;
 
   constexpr bool nan_n_silly_check_cands_every_layer     = false;
   constexpr bool nan_n_silly_print_bad_cands_every_layer = false;

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -190,7 +190,8 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
 
   const auto assignbins = [&](int itrack, float q, float dq, float phi, float dphi){
 
-    float thisPt    = 1.0f/Par[iI].At(itrack,3,0);
+    //Keep in mind that ipt can be negative, so take abs here
+    float thisPt    = std::fabs( 1.0f/Par[iI].At(itrack,3,0));
     float thisEta   = std::fabs( getEta( Par[iI].At(itrack,5,0) ) );
     //
     float min_dq    = L.min_dq();

--- a/mkFit/PropagationMPlex.icc
+++ b/mkFit/PropagationMPlex.icc
@@ -26,8 +26,13 @@ static inline void helixAtRFromIterativeCCS_impl(const    Tf& __restrict__ inPar
       errorProp(n,4,4) = 1.f;
       errorProp(n,5,5) = 1.f;
 
+      //Note that if the charge of the seed is wrong, then in our code we could eventually
+      //get negative values for ipt. The propagation code below assumes ipt is positive and that 
+      //the sign of the charge is included in the factor k.
+      const float chargeFactor = (inPar(n, 3, 0) < 0) ?	-1.f : 1.f;
+
       float r0 = hipo(inPar(n, 0, 0), inPar(n, 1, 0));
-      const float k = inChg(n, 0, 0) * 100.f / (-Config::sol*(pf.use_param_b_field ? Config::BfieldFromZR(inPar(n,2,0),r0) : Config::Bfield));
+      const float k = chargeFactor * inChg(n, 0, 0) * 100.f / (-Config::sol*(pf.use_param_b_field ? Config::BfieldFromZR(inPar(n,2,0),r0) : Config::Bfield));
       const float r = msRad(n, 0, 0);
 
       // if (std::abs(r-r0)<0.0001f) {
@@ -37,7 +42,7 @@ static inline void helixAtRFromIterativeCCS_impl(const    Tf& __restrict__ inPar
 
       const float xin   = inPar(n, 0, 0);
       const float yin   = inPar(n, 1, 0);
-      const float ipt   = inPar(n, 3, 0);
+      const float ipt   = std::abs(inPar(n, 3, 0));
       const float phiin = inPar(n, 4, 0);
       const float theta = inPar(n, 5, 0);
 
@@ -169,7 +174,8 @@ static inline void helixAtRFromIterativeCCS_impl(const    Tf& __restrict__ inPar
       errorProp(n,2,4) = k*dadphi*cosPorT*pt*sinPorT;
       errorProp(n,2,5) =-k*alpha*pt*sinPorT*sinPorT;
 
-      outPar(n, 3, 0) = ipt;
+      //Here we set the sign of the updated track ipt based on whether the original track ipt was negative.
+      outPar(n, 3, 0) = ipt*chargeFactor;
 
       errorProp(n,3,0) = 0.f;
       errorProp(n,3,1) = 0.f;


### PR DESCRIPTION
NEEDS DISCUSSION AND REVIEW
This PR fixes the code to consistently handle the case when the track pt goes negative, corresponding to a change in the charge hypothesis for the particle. This has been discussed at two different mkFit meetings: [Dec 13, 2020](https://indico.cern.ch/event/845069/contributions/3548502/attachments/1962289/3261785/ChargeAssignment.pdf) and [Dec 20, 2020 ](https://indico.cern.ch/event/845070/contributions/3548517/attachments/1965389/3267950/ChargeAssignment.pdf). The benchmarks for TTBar PU50 can be seen [here](http://areinsvo.web.cern.ch/areinsvo/MkFit/Benchmarks/PR251/), demonstrating essentially no change . Note that these results are on top of the Config changes introduced in [PR250](https://github.com/trackreco/mkFit/pull/250). 

Someone needs to closely double check my work to make sure I am doing what I intend to and disentangling the sign of ipt from the charge of the particle. There is some evidence that the track quality gets slightly **worse** in the 10muon sample after my changes. See the summary in the [slides posted here](https://indico.cern.ch/event/845077/). 

10 muon results with duplicate removal applied: [Before](http://areinsvo.web.cern.ch/areinsvo/MkFit/EffHighPt_Jan2020/testHighPt10mu_fixupBadSeeds) and [After](http://areinsvo.web.cern.ch/areinsvo/MkFit/EffHighPt_Jan2020/PR251_10muOffline)

10 muon results without duplicate removal applied: [Before](http://areinsvo.web.cern.ch/areinsvo/MkFit/EffHighPt_Jan2020/PR250_10muOffline_noDupRemoval) and [After](http://areinsvo.web.cern.ch/areinsvo/MkFit/EffHighPt_Jan2020/PR251_10muOffline_noDupRemoval)