### PR TITLE
Update to gcc8, c++17, newer ROOT

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -233,7 +233,7 @@ ifdef DEBUG
 endif
 
 # Set stdlib at the very end, as other flags (i.e. ROOT) can override our choice for which version of c++
-CPPFLAGS += -std=c++14
+CPPFLAGS += -std=c++1z
 
 ################################################################
 # Dependency generation

--- a/xeon_scripts/benchmark-cmssw-ttbar-fulldet-build.sh
+++ b/xeon_scripts/benchmark-cmssw-ttbar-fulldet-build.sh
@@ -48,7 +48,7 @@ then
 elif [[ "${ben_arch}" == "LNX-G" ]]
 then 
     mOpt="-j 32 AVX_512:=1"
-    dir=/data2/slava77/samples
+    dir=/data2
     maxth=64
     maxvu=16
     declare -a nths=("1" "2" "4" "8" "16" "32" "48" "64")
@@ -57,7 +57,7 @@ then
 elif [[ "${ben_arch}" == "LNX-S" ]]
 then 
     mOpt="-j 32 AVX_512:=1"
-    dir=/data2/slava77/samples
+    dir=/data2
     maxth=64
     maxvu=16
     declare -a nths=("1" "2" "4" "8" "16" "32" "48" "64")

--- a/xeon_scripts/init-env.sh
+++ b/xeon_scripts/init-env.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-source /cvmfs/cms.cern.ch/slc7_amd64_gcc630/lcg/root/6.12.07-gnimlf2/etc/profile.d/init.sh
+source /cvmfs/cms.cern.ch/slc7_amd64_gcc820/lcg/root/6.18.04-bcolbf/etc/profile.d/init.sh
 source /opt/intel/bin/compilervars.sh intel64

--- a/xeon_scripts/init-env.sh
+++ b/xeon_scripts/init-env.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
 source /cvmfs/cms.cern.ch/slc7_amd64_gcc820/lcg/root/6.18.04-bcolbf/etc/profile.d/init.sh
+# workaround for https://github.com/cms-sw/cmsdist/issues/5574
+# remove when we switch to a ROOT build where that issues is fixed
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBJPEG_TURBO_ROOT/lib64
 source /opt/intel/bin/compilervars.sh intel64


### PR DESCRIPTION
This PR updates to the CMSSW slc7_amd64_gcc820.  This includes picking up a newer version of ROOT and updating the C++ standard version to c++17.  Standard plots are at https://www.classe.cornell.edu/~dsr/mic-track/pr253/ (I didn't spot any difference from the latest baseline).