### PR TITLE
fix options and intrinsics for gcc8 and avx2

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -72,11 +72,11 @@ OPT := -g -O3
 
 # 4. Vectorization settings
 ifdef AVX_512
-VEC_GCC  := -mavx512f -mavx512cd # -march=native -fopt-info-vec -mavx
-VEC_ICC  := -xHost -qopt-zmm-usage=high #-march=native -mtune=native #-xcore-avx512
+VEC_GCC  := -march=native # -fopt-info-vec -mavx512f -mavx512cd
+VEC_ICC  := -xHost -qopt-zmm-usage=high # -xcore-avx512
 else ifdef AVX2
-VEC_GCC  := -mavx2
-VEC_ICC  := -mavx2
+VEC_GCC  := -mavx2 -mfma
+VEC_ICC  := -mavx2 -mfma
 else
 VEC_GCC  := -mavx # -fopt-info-vec-all
 VEC_ICC  := -mavx
@@ -201,9 +201,8 @@ ifneq ($(CXX),icc)
     ifdef CMSSW_BASE
       CPPFLAGS += -I$(shell cd $$CMSSW_BASE && scram tool tag tbb INCLUDE)
       LDFLAGS_HOST += -L$(shell cd $$CMSSW_BASE && scram tool tag tbb LIBDIR)
-    else ifneq (,$(realpath /opt/rh/python27/root/usr/include))
-      CPPFLAGS += -I/opt/rh/python27/root/usr/include
-      LDFLAGS_HOST += -L/opt/rh/python27/root/usr/lib64
+    else ifdef TBB_GCC
+      TBB_PREFIX = $(TBB_GCC)
     endif
   endif
 endif
@@ -211,7 +210,7 @@ endif
 ifdef WITH_TBB
   # icc finds tbb in its own installation, but allow overriding in case it doesn't
   ifdef TBB_PREFIX
-    CPPFLAGS += -I${TBB_PREFIX}/include
+    CPPFLAGS += -I${TBB_PREFIX}/include/tbb
     LDFLAGS  += -L${TBB_PREFIX}/lib -Wl,-rpath,${TBB_PREFIX}/lib
   endif
   CPPFLAGS += -DTBB

--- a/Makefile.config
+++ b/Makefile.config
@@ -210,7 +210,7 @@ endif
 ifdef WITH_TBB
   # icc finds tbb in its own installation, but allow overriding in case it doesn't
   ifdef TBB_PREFIX
-    CPPFLAGS += -I${TBB_PREFIX}/include/tbb
+    CPPFLAGS += -I${TBB_PREFIX}/include
     LDFLAGS  += -L${TBB_PREFIX}/lib -Wl,-rpath,${TBB_PREFIX}/lib
   endif
   CPPFLAGS += -DTBB

--- a/Matriplex/MatriplexCommon.h
+++ b/Matriplex/MatriplexCommon.h
@@ -15,7 +15,7 @@
 #include "immintrin.h"
 
 #if defined(MPLEX_USE_INTRINSICS)
-
+  // This seems unnecessary: __AVX__ is usually defined for all higher ISA extensions
   #if defined(__MIC__) || defined(__AVX__) || defined(__AVX512F__)
 
     #define MPLEX_INTRINSICS
@@ -37,14 +37,15 @@
     #define MUL(a, b)     _mm512_mul_ps(a, b)
     #define FMA(a, b, v)  _mm512_fmadd_ps(a, b, v)
 
-  #elif defined(__AVX2__)
+  #elif defined(__AVX2__) && defined(__FMA__)
 
     typedef __m256 IntrVec_t;
     #define MPLEX_INTRINSICS_WIDTH_BYTES  32
     #define MPLEX_INTRINSICS_WIDTH_BITS  256
     #define AVX2_INTRINSICS
     #define GATHER_INTRINSICS
-    #define GATHER_IDX_LOAD(name, arr)  __m256i name = _mm256_load_epi32(arr);
+    // Previously used _mm256_load_epi32(arr) here, but that's part of AVX-512F, not AVX2
+    #define GATHER_IDX_LOAD(name, arr)  __m256i name = _mm256_load_si256(reinterpret_cast<const __m256i *>(arr));
 
     #define LD(a, i)      _mm256_load_ps(&a[i*N+n])
     #define ST(a, i, r)   _mm256_store_ps(&a[i*N+n], r)

--- a/mkFit/MatriplexPackers.h
+++ b/mkFit/MatriplexPackers.h
@@ -10,7 +10,7 @@ namespace mkfit {
 
 
 //==============================================================================
-// MatriplexErrParPackerSlurpIn
+// MatriplexPackerSlurpIn
 //==============================================================================
 
 template<typename D>

--- a/xeon_scripts/init-env.sh
+++ b/xeon_scripts/init-env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-
 source /cvmfs/cms.cern.ch/slc7_amd64_gcc820/lcg/root/6.18.04-bcolbf/etc/profile.d/init.sh
+export TBB_GCC=/cvmfs/cms.cern.ch/slc7_amd64_gcc820/external/tbb/2019_U9
 # workaround for https://github.com/cms-sw/cmsdist/issues/5574
 # remove when we switch to a ROOT build where that issues is fixed
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBJPEG_TURBO_ROOT/lib64


### PR DESCRIPTION
This PR addresses issues #261 and #171. The changes are pretty minor and mostly affect gcc compilation. A single AVX2 intrinsic function was changed in MatriplexCommon.h, as the one previously used was actually borrowed from AVX-512, and gcc is extremely strict about which immintrin.h is included for a given set of x86 options. Also the -mfma flag was added for AVX2, as it turns out that the FMA instructions are not automatically part of the AVX2 ISA extension.

I didn't run the usual benchmarks because none of these changes touches our usual benchmark build, which relies on icc and AVX-512.

However, in the course of testing, I noticed that the number of builtcands would vary slightly depending on compiler and AVX level. I'll open a separate issue about that, because the issue appears to predate the changes in this PR (it was happening as far back as PR #229).