### PR TITLE
Better temporary fix for negative covariance matrix entries

### DIFF
--- a/Track.cc
+++ b/Track.cc
@@ -92,7 +92,7 @@ bool TrackBase::hasSillyValues(bool dump, bool fix, const char* pref)
           if (dump) printf("%s (label=%d):", pref, label());
         }
         if (dump) printf(" (%d,%d)=%e", i, j, state_.errors.At(i,j));
-        if (fix)  state_.errors.At(i,j) = 1;
+        if (fix)  state_.errors.At(i,j) = 0.00001;
       }
     }
   }


### PR DESCRIPTION
This PR introduces a better fix to the negative entries in the covariance matrix and builds upon [PR250](https://github.com/trackreco/mkFit/pull/250). By setting the negative entries to 10^-5 rather than 1, we recover most of the resolution in eta and some of the increase in duplicate rate. 

This is most obvious using the high stats 10 muon sample that extends to pt = 1000 GeV:
[Before PR250](http://areinsvo.web.cern.ch/areinsvo/MkFit/EffHighPt_Jan2020/testHighPt10mu_master/SIMVAL_MTV_SEED/diffs/): Duplicate rate was 11.4%
[After PR250](http://areinsvo.web.cern.ch/areinsvo/MkFit/EffHighPt_Jan2020/testHighPt10mu_fixupBadSeeds/SIMVAL_MTV_SEED/diffs/) (negative entries set to 1): Duplicate rate is 18.4%
[This PR](http://areinsvo.web.cern.ch/areinsvo/MkFit/EffHighPt_Jan2020/set0p00001/SIMVAL_MTV_SEED/diffs) (negative entries set to 10^-5): Duplicate rate is 15.9%

I tried 10^-3 and 10^-6 as well, but 10^-5 had the best performance.

Benchmarks for the ttbar PU 50 sample are here. I didn't notice any major changes since the last PR.
http://areinsvo.web.cern.ch/areinsvo/MkFit/Benchmarks/PR263