### PR TITLE
Fix backward fit for tracks without a hit on innermost pixel layer

### DIFF
--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -995,7 +995,7 @@ void MkFinder::BkFitFitTracks(const EventOfHits   & eventofhits,
     {
       while (CurHit[i] >= 0 && HoTArr[ i ][ CurHit[i] ].index < 0) --CurHit[i];
 
-      if (HoTArr[ i ][ CurHit[i] ].layer == layer)
+      if (CurHit[i] >= 0 && HoTArr[ i ][ CurHit[i] ].layer == layer)
       {
         const Hit &hit = L.GetHit( HoTArr[ i ][ CurHit[i] ].index );
         msErr.CopyIn(i, hit.errArray());


### PR DESCRIPTION
Otherwise triplet seeds without hits on BPix1 will lead to segfaults.

The fix itself came from @osschar.