### PR TITLE
fix scale param to mask_i32gather to be a compile time constant

### DIFF
--- a/Matriplex/Matriplex.h
+++ b/Matriplex/Matriplex.h
@@ -100,7 +100,8 @@ public:
 
 #if defined(MIC_INTRINSICS)
 
-   void SlurpIn(const T *arr, __m512i& vi, int scale, const int N_proc = N)
+   template<typename U>
+   void SlurpIn(const T *arr, __m512i& vi, const U&, const int N_proc = N)
    {
       //_mm512_prefetch_i32gather_ps(vi, arr, 1, _MM_HINT_T0);
 
@@ -111,7 +112,7 @@ public:
       {
          //_mm512_prefetch_i32gather_ps(vi, arr+2, 1, _MM_HINT_NTA);
 
-         __m512 reg = _mm512_mask_i32gather_ps(src, k, vi, arr, scale);
+         __m512 reg = _mm512_mask_i32gather_ps(src, k, vi, arr, sizeof(U));
          _mm512_mask_store_ps(&fArray[i*N], k, reg);
       }
    }
@@ -159,7 +160,8 @@ public:
 
 #elif defined(AVX2_INTRINSICS)
 
-   void SlurpIn(const T *arr, __m256i& vi, int scale, const int N_proc = N)
+   template<typename U>
+   void SlurpIn(const T *arr, __m256i& vi, const U&, const int N_proc = N)
    {
       // Casts to float* needed to "support" also T=HitOnTrack.
       // Not needed for AVX_512 (?).
@@ -178,7 +180,7 @@ public:
       k = k_master;
       for (int i = 0; i < kSize; ++i, ++arr)
       {
-         __m256 reg = _mm256_mask_i32gather_ps(src, (float*) arr, vi, (__m256) k, scale);
+         __m256 reg = _mm256_mask_i32gather_ps(src, (float*) arr, vi, (__m256) k, sizeof(U));
          // Restore mask (docs say gather clears it but it doesn't seem to).
          k = k_master;
          _mm256_maskstore_ps((float*) &fArray[i*N], k, reg);

--- a/Matriplex/MatriplexSym.h
+++ b/Matriplex/MatriplexSym.h
@@ -119,7 +119,8 @@ public:
 
 #if defined(MIC_INTRINSICS)
 
-   void SlurpIn(const T *arr, __m512i& vi, int scale, const int N_proc = N)
+   template<typename U>
+   void SlurpIn(const T *arr, __m512i& vi, const U&, const int N_proc = N)
    {
       //_mm512_prefetch_i32gather_ps(vi, arr, 1, _MM_HINT_T0);
 
@@ -130,7 +131,7 @@ public:
       {
          //_mm512_prefetch_i32gather_ps(vi, arr+2, 1, _MM_HINT_NTA);
 
-         __m512 reg = _mm512_mask_i32gather_ps(src, k, vi, arr, scale);
+         __m512 reg = _mm512_mask_i32gather_ps(src, k, vi, arr, sizeof(U));
          _mm512_mask_store_ps(&fArray[i*N], k, reg);
       }
    }
@@ -179,7 +180,8 @@ public:
 
 #elif defined(AVX2_INTRINSICS)
 
-   void SlurpIn(const T *arr, __m256i& vi, int scale, const int N_proc = N)
+   template<typename U>
+   void SlurpIn(const T *arr, __m256i& vi, const U&, const int N_proc = N)
    {
       const __m256 src = { 0 };
 
@@ -190,7 +192,7 @@ public:
       k = k_master;
       for (int i = 0; i < kSize; ++i, ++arr)
       {
-         __m256 reg = _mm256_mask_i32gather_ps(src, arr, vi, (__m256) k, scale);
+         __m256 reg = _mm256_mask_i32gather_ps(src, arr, vi, (__m256) k, sizeof(U));
          // Restore mask (docs say gather clears it but it doesn't seem to).
          k = k_master;
          _mm256_maskstore_ps(&fArray[i*N], k, reg);

--- a/mkFit/MatriplexPackers.h
+++ b/mkFit/MatriplexPackers.h
@@ -66,7 +66,8 @@ public:
 
 #if defined(GATHER_INTRINSICS)
       GATHER_IDX_LOAD(vi, m_idx);
-      mplex.SlurpIn(m_base + base_offset, vi, sizeof(D), m_pos);
+      D scale;
+      mplex.SlurpIn(m_base + base_offset, vi, scale, m_pos);
 #else
       mplex.SlurpIn(m_base + base_offset, m_idx, m_pos);
 #endif
@@ -125,8 +126,9 @@ public:
 
 #if defined(GATHER_INTRINSICS)
       GATHER_IDX_LOAD(vi, this->m_idx);
-      err.SlurpIn(this->m_base,               vi, sizeof(D), this->m_pos);
-      par.SlurpIn(this->m_base + m_off_param, vi, sizeof(D), this->m_pos);
+      D scale;
+      err.SlurpIn(this->m_base,               vi, scale, this->m_pos);
+      par.SlurpIn(this->m_base + m_off_param, vi, scale, this->m_pos);
 #else
       err.SlurpIn(this->m_base,               this->m_idx, this->m_pos);
       par.SlurpIn(this->m_base + m_off_param, this->m_idx, this->m_pos);

--- a/mkFit/MatriplexPackers.h
+++ b/mkFit/MatriplexPackers.h
@@ -66,8 +66,7 @@ public:
 
 #if defined(GATHER_INTRINSICS)
       GATHER_IDX_LOAD(vi, m_idx);
-      D scale;
-      mplex.SlurpIn(m_base + base_offset, vi, scale, m_pos);
+      mplex.SlurpIn(m_base + base_offset, vi, D(), m_pos);
 #else
       mplex.SlurpIn(m_base + base_offset, m_idx, m_pos);
 #endif
@@ -126,9 +125,8 @@ public:
 
 #if defined(GATHER_INTRINSICS)
       GATHER_IDX_LOAD(vi, this->m_idx);
-      D scale;
-      err.SlurpIn(this->m_base,               vi, scale, this->m_pos);
-      par.SlurpIn(this->m_base + m_off_param, vi, scale, this->m_pos);
+      err.SlurpIn(this->m_base,               vi, D(), this->m_pos);
+      par.SlurpIn(this->m_base + m_off_param, vi, D(), this->m_pos);
 #else
       err.SlurpIn(this->m_base,               this->m_idx, this->m_pos);
       par.SlurpIn(this->m_base + m_off_param, this->m_idx, this->m_pos);


### PR DESCRIPTION
The "scale" parameter to the mask_i32gather intrinsics is supposed to be a compile time constant.  icc with optimization lets this get by, but with optimization off it doesn't, and clang catches the problem regardless of optimization level.  This change templates the intrinsics versions of SlurpIn so that we can use type deduction to get a constexpr scale.  This change should have *no* physics or timing consequences, it only serves to make compilation possible with picky compilers, so I'm not planning on running validation.