### PR TITLE
Duplicate Removal

### DIFF
--- a/Config.cc
+++ b/Config.cc
@@ -87,8 +87,8 @@ namespace Config
 
   bool  removeDuplicates = false;
   bool  useHitsForDuplicates = true;
-  float maxdPhi = 0.4;
-  float maxdPt  = 0.7;
+  float maxdPhi = 0.5;
+  float maxdPt  = 0.5;
   float maxdEta = 0.05;
   float minFracHitsShared = 0.75;
   float maxdRSquared = 0.000001; //corresponds to maxdR of 0.001

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -1312,10 +1312,10 @@ void MkBuilder::find_duplicates(TrackVec& tracks)
       }
       else
       {
-        maxpt = std::max(pt1,track2.pT());
-        if(maxpt ==0) continue;
+        if(pt1 ==0) continue;
+        if(track2.pT() ==0) continue;
 
-        if(std::abs(track2.pT() - pt1)/maxpt < Config::maxdPt)
+        if(std::abs((1/track2.pT()) - (1/pt1)) < Config::maxdPt)
         {
           if(Config::useHitsForDuplicates)
           {


### PR DESCRIPTION
Responding to issue #251  
Changed the pt cut in duplicate removal from |pt2-pt1|/maxpt to |1/pt2 -1/pt1|
changed the maxdPhi cut to 0.5 and the maxdPt cut to 0.5
Benchmarks for ttbar can be found here: http://mireid.web.cern.ch/mireid/mkFit_keep/duplicate_rm/benchmarks_duplicateRemovalPR_ttbar/
Benchmarks for muons can be found here: 
http://mireid.web.cern.ch/mireid/mkFit_keep/duplicate_rm/benchmarks_duplicateRemovalPR_muons/