### PR TITLE
Update charge param if ipt is negative

### DIFF
--- a/mkFit/KalmanUtilsMPlex.cc
+++ b/mkFit/KalmanUtilsMPlex.cc
@@ -468,7 +468,7 @@ void kalmanUpdate(const MPlexLS &psErr,  const MPlexLV& psPar,
                   outErr, outPar, dummy_chi2, N_proc);
 }
 
-void kalmanPropagateAndUpdate(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI &inChg,
+void kalmanPropagateAndUpdate(const MPlexLS &psErr,  const MPlexLV& psPar, MPlexQI &Chg,
                               const MPlexHS &msErr,  const MPlexHV& msPar,
                                     MPlexLS &outErr,       MPlexLV& outPar,
                               const int      N_proc, const PropagationFlags propFlags)
@@ -484,7 +484,7 @@ void kalmanPropagateAndUpdate(const MPlexLS &psErr,  const MPlexLV& psPar, const
       msRad.At(n, 0, 0) = std::hypot(msPar.ConstAt(n, 0, 0), msPar.ConstAt(n, 1, 0));
     }
 
-    propagateHelixToRMPlex(psErr, psPar, inChg, msRad, propErr, propPar, N_proc, propFlags);
+    propagateHelixToRMPlex(psErr, psPar, Chg, msRad, propErr, propPar, N_proc, propFlags);
 
     kalmanOperation(KFO_Update_Params, propErr, propPar, msErr, msPar,
                     outErr, outPar, dummy_chi2, N_proc);
@@ -493,6 +493,14 @@ void kalmanPropagateAndUpdate(const MPlexLS &psErr,  const MPlexLV& psPar, const
   {
     kalmanOperation(KFO_Update_Params, psErr, psPar, msErr, msPar,
                     outErr, outPar, dummy_chi2, N_proc);
+  }
+  for (int n = 0; n < NN; ++n)
+  {
+    if (outPar.At(n,3,0) < 0)
+    {
+      Chg.At(n, 0, 0) = -1.0*Chg.ConstAt(n, 0, 0);
+      outPar.At(n,3,0) = std::abs(outPar.At(n,3,0));
+    }
   }
 }
 
@@ -686,7 +694,7 @@ void kalmanUpdateEndcap(const MPlexLS &psErr,  const MPlexLV& psPar,
                         outErr, outPar, dummy_chi2, N_proc);
 }
 
-void kalmanPropagateAndUpdateEndcap(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI &inChg,
+void kalmanPropagateAndUpdateEndcap(const MPlexLS &psErr,  const MPlexLV& psPar, MPlexQI &Chg,
                                     const MPlexHS &msErr,  const MPlexHV& msPar,
                                           MPlexLS &outErr,       MPlexLV& outPar,
                                     const int      N_proc, const PropagationFlags propFlags)
@@ -702,7 +710,7 @@ void kalmanPropagateAndUpdateEndcap(const MPlexLS &psErr,  const MPlexLV& psPar,
       msZ.At(n, 0, 0) = msPar.ConstAt(n, 2, 0);
     }
 
-    propagateHelixToZMPlex(psErr, psPar, inChg, msZ, propErr, propPar, N_proc, propFlags);
+    propagateHelixToZMPlex(psErr, psPar, Chg, msZ, propErr, propPar, N_proc, propFlags);
 
     kalmanOperationEndcap(KFO_Update_Params, propErr, propPar, msErr, msPar,
                           outErr, outPar, dummy_chi2, N_proc);
@@ -711,6 +719,14 @@ void kalmanPropagateAndUpdateEndcap(const MPlexLS &psErr,  const MPlexLV& psPar,
   {
     kalmanOperationEndcap(KFO_Update_Params, psErr, psPar, msErr, msPar,
                           outErr, outPar, dummy_chi2, N_proc);
+  }
+  for (int n = 0; n < NN; ++n)
+  {
+    if (outPar.At(n,3,0) < 0)
+    {
+      Chg.At(n, 0, 0) = -1.0*Chg.ConstAt(n, 0, 0);
+      outPar.At(n,3,0) = std::abs(outPar.At(n,3,0));
+    }
   }
 }
 

--- a/mkFit/KalmanUtilsMPlex.h
+++ b/mkFit/KalmanUtilsMPlex.h
@@ -26,7 +26,7 @@ void kalmanUpdate(const MPlexLS &psErr,  const MPlexLV& psPar,
                         MPlexLS &outErr,       MPlexLV& outPar,
                   const int      N_proc);
 
-void kalmanPropagateAndUpdate(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI &inChg,
+void kalmanPropagateAndUpdate(const MPlexLS &psErr,  const MPlexLV& psPar, MPlexQI &Chg,
                               const MPlexHS &msErr,  const MPlexHV& msPar,
                                     MPlexLS &outErr,       MPlexLV& outPar,
                               const int      N_proc, const PropagationFlags propFlags);
@@ -57,7 +57,7 @@ void kalmanUpdateEndcap(const MPlexLS &psErr,  const MPlexLV& psPar,
                               MPlexLS &outErr,       MPlexLV& outPar,
                         const int      N_proc);
 
-void kalmanPropagateAndUpdateEndcap(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI &inChg,
+void kalmanPropagateAndUpdateEndcap(const MPlexLS &psErr,  const MPlexLV& psPar, MPlexQI &Chg,
                                     const MPlexHS &msErr,  const MPlexHV& msPar,
                                           MPlexLS &outErr,       MPlexLV& outPar,
                                     const int      N_proc, const PropagationFlags propFlags);

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -843,6 +843,7 @@ void MkFinder::CopyOutParErr(std::vector<CombCandidate>& seed_cand_vec,
     // Set the track state to the updated parameters
     Err[iO].CopyOut(i, cand.errors_nc().Array());
     Par[iO].CopyOut(i, cand.parameters_nc().Array());
+    cand.setCharge(Chg(i,0,0));
 
     dprint((outputProp?"propagated":"updated") << " track parameters x=" << cand.parameters()[0]
               << " y=" << cand.parameters()[1]

--- a/mkFit/SteeringParams.h
+++ b/mkFit/SteeringParams.h
@@ -15,7 +15,7 @@ class MkFinder;
                           const MPlexHS &,  const MPlexHV &, \
                           MPlexQF &,  const int, const PropagationFlags
 
-#define UPDATE_PARAM_ARGS const MPlexLS &,  const MPlexLV &, const MPlexQI &, \
+#define UPDATE_PARAM_ARGS const MPlexLS &,  const MPlexLV &, MPlexQI &, \
                           const MPlexHS &,  const MPlexHV &, \
                                 MPlexLS &,        MPlexLV &, const int, const PropagationFlags
 


### PR DESCRIPTION
This PR addresses the charge issue, and flips the charge and the sign of ipt if ipt goes negative. This is a better version of the fix that I originally implemented in [PR252](https://github.com/trackreco/mkFit/pull/252) (which I will close), because now I deal with the problem at the source instead of adding std::abs everywhere that ipt might be negative. 

The physics performance from these changes can be seen in the slides [here](https://cernbox.cern.ch/index.php/s/PyTa2SM9D54JmdF). The conclusions are similar to before: these fixes seem to make the track quality and efficiency slightly worse.

The plots for ttbar PU50 are [here for the baseline (head of devel after the merge of PR271)](http://areinsvo.web.cern.ch/areinsvo/MkFit/ChargeAssignment/April2020/baseline/) and [here with the charge flip fix](http://areinsvo.web.cern.ch/areinsvo/MkFit/ChargeAssignment/April2020/betterChargeFlipFix/). 

The plots for the 10muon sample using HLT triplets are [here for the baseline](http://areinsvo.web.cern.ch/areinsvo/MkFit/ChargeAssignment/April2020/baseline_10muHLT3/) and [here with the charge flip fix](http://areinsvo.web.cern.ch/areinsvo/MkFit/ChargeAssignment/April2020/chargeFlipv2_10muHLT3/).