### PR TITLE
Use param b field in building and backward fit

### DIFF
--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -23,9 +23,9 @@ namespace
     Config::chi2Cut          = 30;
 
     Config::finding_requires_propagation_to_hit_pos = true;
-    Config::finding_inter_layer_pflags = PropagationFlags(PF_apply_material);
+    Config::finding_inter_layer_pflags = PropagationFlags(PF_use_param_b_field | PF_apply_material);
     Config::finding_intra_layer_pflags = PropagationFlags(PF_none);
-    Config::backward_fit_pflags        = PropagationFlags(PF_apply_material);
+    Config::backward_fit_pflags        = PropagationFlags(PF_use_param_b_field | PF_apply_material);
     Config::forward_fit_pflags         = PropagationFlags(PF_use_param_b_field | PF_apply_material);
     Config::seed_fit_pflags            = PropagationFlags(PF_none);
     Config::pca_prop_pflags            = PropagationFlags(PF_none);


### PR DESCRIPTION
The parametric B field should be included in the new tuning done for Pandora's Box. The effect of turning on the parameterization in the current head of devel has been documented extensively in https://github.com/trackreco/mkFit/issues/124.