### PR TITLE
add hit masks per hit to mark hits available for specific iterations

### DIFF
--- a/Event.cc
+++ b/Event.cc
@@ -57,6 +57,7 @@ Event::Event(int evtID) :
 {
   reset_nan_n_silly_counters();
   layerHits_.resize(Config::nTotalLayers);
+  layerHitMasks_.resize(Config::nTotalLayers);
 }
 
 Event::Event(const Geometry& g, Validation& v, int evtID, int threads) :
@@ -65,6 +66,7 @@ Event::Event(const Geometry& g, Validation& v, int evtID, int threads) :
 {
   reset_nan_n_silly_counters();
   layerHits_.resize(Config::nTotalLayers);
+  layerHitMasks_.resize(Config::nTotalLayers);
 
   validation_.resetValidationMaps(); // need to reset maps for every event.
 }
@@ -497,6 +499,7 @@ void Event::read_in(DataFile &data_file, FILE *in_fp)
   int nl;
   fread(&nl, sizeof(int), 1, fp);
   layerHits_.resize(nl);
+  layerHitMasks_.resize(nl);
   for (int il = 0; il<nl; ++il) {
     int nh;
     fread(&nh, sizeof(int), 1, fp);

--- a/Event.cc
+++ b/Event.cc
@@ -1059,7 +1059,7 @@ void Event::relabel_cmsswtracks_from_seeds()
 int DataFile::OpenRead(const std::string& fname, bool set_n_layers)
 {
   constexpr int min_ver = 4;
-  constexpr int max_ver = 4;
+  constexpr int max_ver = 5;
 
   f_fp = fopen(fname.c_str(), "r");
   assert (f_fp != 0 && "Opening of input file failed.");

--- a/Event.h
+++ b/Event.h
@@ -67,6 +67,7 @@ public:
   std::mutex       mcGatherMutex_;
   std::atomic<int> mcHitIDCounter_;
   std::vector<HitVec> layerHits_;
+  std::vector<std::vector<uint64_t> > layerHitMasks_;//aligned with layerHits_
   MCHitInfoVec simHitsInfo_;
 
   TrackVec simTracks_, seedTracks_, candidateTracks_, fitTracks_;
@@ -115,7 +116,8 @@ struct DataFile
   {
     ES_SimTrackStates = 0x1,
     ES_Seeds          = 0x2,
-    ES_CmsswTracks    = 0x4
+    ES_CmsswTracks    = 0x4,
+    ES_HitIterMasks   = 0x8
   };
 
   FILE *f_fp  =  0;
@@ -130,6 +132,7 @@ struct DataFile
   bool HasSimTrackStates() const { return f_header.f_extra_sections & ES_SimTrackStates; }
   bool HasSeeds()          const { return f_header.f_extra_sections & ES_Seeds; }
   bool HasCmsswTracks()    const { return f_header.f_extra_sections & ES_CmsswTracks; }
+  bool HasHitIterMasks()   const { return f_header.f_extra_sections & ES_HitIterMasks; }
 
   int  OpenRead (const std::string& fname, bool set_n_layers = false);
   void OpenWrite(const std::string& fname, int nev, int extra_sections=0);

--- a/Event.h
+++ b/Event.h
@@ -95,7 +95,7 @@ typedef std::vector<Event> EventVec;
 struct DataFileHeader
 {
   int f_magic          = 0xBEEF;
-  int f_format_version = 4;
+  int f_format_version = 5;
   int f_sizeof_track   = sizeof(Track);
   int f_sizeof_hit     = sizeof(Hit);
   int f_sizeof_hot     = sizeof(HitOnTrack);

--- a/tkNtuple/WriteMemoryFile.cc
+++ b/tkNtuple/WriteMemoryFile.cc
@@ -77,6 +77,7 @@ int main(int argc, char *argv[])
   bool cleanSimTracks = false;
   bool writeAllEvents = false;
   bool writeRecTracks = false;
+  bool writeHitIterMasks = false;
   bool applyCCC       = false;
   bool allSeeds       = false;
 
@@ -133,6 +134,10 @@ int main(int argc, char *argv[])
       else if (*i == "--write-rec-tracks")
 	{
 	  writeRecTracks = true;
+	}
+      else if (*i == "--write-hit-iter-masks")
+	{
+	  writeHitIterMasks = true;
 	}
       else if (*i == "--apply-ccc")
 	{
@@ -375,6 +380,7 @@ int main(int argc, char *argv[])
   vector<float>*  pix_zx = 0;
   vector<int>*    pix_csize_col = 0;
   vector<int>*    pix_csize_row = 0;
+  vector<uint64_t>* pix_usedMask = 0;
   //these were renamed in CMSSW_9_1_0: auto-detect
   bool has910_det_lay = t->GetBranch("pix_det") == nullptr;
   if (has910_det_lay){
@@ -396,6 +402,9 @@ int main(int argc, char *argv[])
   t->SetBranchAddress("pix_zx",&pix_zx);
   t->SetBranchAddress("pix_clustSizeCol",&pix_csize_col);
   t->SetBranchAddress("pix_clustSizeRow",&pix_csize_row);
+  if (writeHitIterMasks) {
+    t->SetBranchAddress("pix_usedMask", &pix_usedMask);
+  }
 
   vector<vector<int> >*    pix_simHitIdx = 0;
   t->SetBranchAddress("pix_simHitIdx", &pix_simHitIdx);
@@ -456,6 +465,7 @@ int main(int argc, char *argv[])
   vector<float>*  str_zx = 0;
   vector<float>*  str_chargePerCM = 0;
   vector<int>*    str_csize = 0;
+  vector<uint64_t>* str_usedMask = 0;
   t->SetBranchAddress("str_isBarrel",&str_isBarrel);
   t->SetBranchAddress("str_isStereo",&str_isStereo);
   if (has910_det_lay){
@@ -478,6 +488,9 @@ int main(int argc, char *argv[])
   t->SetBranchAddress("str_zx",&str_zx);
   t->SetBranchAddress("str_chargePerCM",&str_chargePerCM);
   t->SetBranchAddress("str_clustSize", &str_csize);
+  if (writeHitIterMasks) {
+    t->SetBranchAddress("str_usedMask", &str_usedMask);
+  }
 
   vector<vector<int> >*    str_simHitIdx = 0;
   t->SetBranchAddress("str_simHitIdx", &str_simHitIdx);
@@ -490,6 +503,7 @@ int main(int argc, char *argv[])
   DataFile data_file;
   int outOptions = DataFile::ES_Seeds;
   if (writeRecTracks) outOptions |= DataFile::ES_CmsswTracks;
+  if (writeHitIterMasks) outOptions |= DataFile::ES_HitIterMasks;
   if (maxevt < 0) maxevt = totentries;
   data_file.OpenWrite(outputFileName, std::min(maxevt, totentries), outOptions);
 
@@ -890,9 +904,11 @@ int main(int argc, char *argv[])
 
     
     vector<vector<Hit> > &layerHits_   = EE.layerHits_;
+    vector<vector<uint64_t> > & layerHitMasks_ = EE.layerHitMasks_;
     vector<MCHitInfo>    &simHitsInfo_ = EE.simHitsInfo_;
     int totHits = 0;
     layerHits_.resize(nTotalLayers);
+    layerHitMasks_.resize(nTotalLayers);
     for (unsigned int ipix = 0; ipix < pix_lay->size(); ++ipix) {
       int ilay = -1;
       ilay = lnc.convertLayerNumber(pix_det->at(ipix),pix_lay->at(ipix),useMatched,-1,pix_z->at(ipix)>0);
@@ -930,6 +946,7 @@ int main(int argc, char *argv[])
       Hit hit(pos, err, totHits);
       hit.setupAsPixel(imoduleid, pix_csize_row->at(ipix), pix_csize_col->at(ipix));
       layerHits_[ilay].push_back(hit);
+      if (writeHitIterMasks) layerHitMasks_[ilay].push_back(pix_usedMask->at(ipix));
       MCHitInfo hitInfo(simTkIdx, ilay, layerHits_[ilay].size()-1, totHits);
       simHitsInfo_.push_back(hitInfo);
       totHits++;
@@ -1023,6 +1040,7 @@ int main(int argc, char *argv[])
           Hit hit(pos, err, totHits);
           hit.setupAsStrip(imoduleid, str_chargePerCM->at(istr), str_csize->at(istr));
           layerHits_[ilay].push_back(hit);
+          if (writeHitIterMasks) layerHitMasks_[ilay].push_back(str_usedMask->at(istr));
 	  MCHitInfo hitInfo(simTkIdx, ilay, layerHits_[ilay].size()-1, totHits);
 	  simHitsInfo_.push_back(hitInfo);
 	  totHits++;

--- a/tkNtuple/WriteMemoryFile.cc
+++ b/tkNtuple/WriteMemoryFile.cc
@@ -1077,7 +1077,10 @@ int main(int argc, char *argv[])
 	for (int il = 0; il<nl; ++il) {
 	  int nh = layerHits_[il].size();
 	  for (int ih=0; ih<nh; ++ih ) {
-	    printf("lay=%i idx=%i mcid=%i x=(%6.3f, %6.3f, %6.3f) r=%6.3f\n",il+1,ih,layerHits_[il][ih].mcHitID(),layerHits_[il][ih].x(),layerHits_[il][ih].y(),layerHits_[il][ih].z(),sqrt(pow(layerHits_[il][ih].x(),2)+pow(layerHits_[il][ih].y(),2)));
+	    printf("lay=%i idx=%i mcid=%i x=(%6.3f, %6.3f, %6.3f) r=%6.3f mask=0x%x\n",il+1,ih,layerHits_[il][ih].mcHitID(),
+                   layerHits_[il][ih].x(),layerHits_[il][ih].y(),layerHits_[il][ih].z(),
+                   sqrt(pow(layerHits_[il][ih].x(),2)+pow(layerHits_[il][ih].y(),2)),
+                   writeHitIterMasks ? layerHitMasks_[il][ih] : 0);
 	  }
 	}
 


### PR DESCRIPTION
The purpose is to pass the information about hits allowed/blocked to be used in a specific iteration to `mkfit::Event`.

- `layerHitMasks_` of type `vector<vector<uint64_t> >` is added to `mkfit::Event`, it should be aligned with `layerHits_` and provides a mask of bits which show with 0/1 if a hit is allowed/blocked to be used in a given iteration. The bit order is the same as `TrackBase::TrackAlgorithm`
    - file format version is updated to 5; reading of version 4 is supported
    - unless `layerHitMasks_` are read from a file via `Event::read_in`, for other Event initialization via `read_in` and `Simulate` the masks are filled with 0 (all hits unmasked)
- WriteMemoryFile.cc can write the masks to the file if enabled with `--write-hit-iter-masks`

I did not run the validation yet; no changes are expected at this point. Still, the following better be tested first
- [x] reading the old v4 files
    - timing looks the same between baseline as of #279 http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/val/phi3/devel-pr279/benchmarks/MultEvInFlight/SKL-SP_CMSSW_TTbar_PU50_CE_MEIF_time.png and this PR as of 
3c860d5  http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/val/phi3/devel-pr279-iters/3c860d5/benchmarks/MultEvInFlight/SKL-SP_CMSSW_TTbar_PU50_CE_MEIF_time.png
    - the efficiency is identical as expected http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/val/phi3/devel-pr279/benchmarks/SIMVAL_MTV_SEED/SKL-SP_CMSSW_TTbar_PU50_eff_eta_build_pt0p0_SIMVALSEED.png in baseline vs http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/val/phi3/devel-pr279-iters/3c860d5/benchmarks/SIMVAL_MTV_SEED/SKL-SP_CMSSW_TTbar_PU50_eff_eta_build_pt0p0_SIMVALSEED.png in this PR as of 3c860d5
- [ ] reading the new files

@mmasciov I hope that the changes here (as of PR open, at least) are small enough to not interfere with your setup for using multiple iterations.