### PR TITLE
swap bits of algorithm and overlap

### DIFF
--- a/Track.h
+++ b/Track.h
@@ -229,11 +229,11 @@ public:
 	// Whether or not the track matched to another track and had the lower cand score
 	bool duplicate : 1;
 
-        // Temporary store number of overlaps for Track here
-        int n_overlaps : 8;
-
         // Tracking iteration/algorithm
         unsigned int algorithm : 6;
+
+        // Temporary store number of overlaps for Track here
+        int n_overlaps : 8;
 
         // The remaining bits.
         unsigned int _free_bits_ : 11;


### PR DESCRIPTION
swap of the bits containing the "algorithm" and "overlap" information, in order to read the algorithm flag from the most recent binary files (e.g. /data2/slava77/analysis/CMSSW_10_4_0_patch1_mkFit/pass-df52fcc/initialStep/default/11024.0_TTbar_13/AVE_50_BX01_25ns/RAW4NT/memoryFile.fv5.clean.writeAll.CCC1620.recT.allSeeds.masks.201023-64302e5.bin ). the overlap bits are going to be added accordingly