### PR TITLE
Call find_duplicates() in run_OneIteration()

### DIFF
--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -500,6 +500,7 @@ void run_OneIteration(const TrackerInfo& trackerInfo, const IterationConfig &itc
 
   if (do_remove_duplicates)
   {
+    StdSeq::find_duplicates(out_tracks);
     StdSeq::remove_duplicates(out_tracks);
   }
 


### PR DESCRIPTION
Spotted as part of https://github.com/trackreco/cmssw/pull/12 as a significant increase of duplicate rate that this PR largely fixes.