### PR TITLE
New tuning after pandoras box

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -350,9 +350,11 @@ namespace Config
   constexpr float track_ptlow = 0.9;
 
   // sorting config (bonus,penalty)
-  constexpr float validHitBonus_ = 10;
+  constexpr float validHitBonus_ = 4;
+  constexpr float validHitSlope_ = 0.2;
   constexpr float overlapHitBonus_ = 0; // set to negative for penalty
-  constexpr float missingHitPenalty_ = 10;
+  constexpr float missingHitPenalty_ = 8;
+  constexpr float tailMissingHitPenalty_ = 3;
 
   // Threading
   extern int    numThreadsFinder;

--- a/Track.h
+++ b/Track.h
@@ -32,6 +32,7 @@ public:
   int   hitIdx; // hit index
   unsigned int   module; // module id
   int   nhits;  // number of hits (used for sorting)
+  int   ntailholes; // number of holes at the end of the track (used for sorting)
   int   noverlaps; // number of overlaps (used for sorting)
   int   nholes;  // number of holes (used for sorting)
   unsigned int seedtype; // seed type idx (used for sorting: 0 = not set; 1 = high pT central seeds; 2 = low pT endcap seeds; 3 = all other seeds)
@@ -637,6 +638,7 @@ inline float getScoreWorstPossible()
 
 inline float getScoreCalc(const unsigned int seedtype,
                           const int nfoundhits,
+			  const int ntailholes,
                           const int noverlaphits,
                           const int nmisshits,
                           const float chi2,
@@ -644,51 +646,44 @@ inline float getScoreCalc(const unsigned int seedtype,
 {
   //// Do not allow for chi2<0 in score calculation
   // if(chi2<0) chi2=0.f;
-  float score_ = Config::validHitBonus_*nfoundhits + Config::overlapHitBonus_*noverlaphits -
-                 Config::missingHitPenalty_*nmisshits - chi2;
-  if(seedtype==2) {
-    score_ -= 0.5f*(Config::validHitBonus_)*nfoundhits;
+
+  float maxBonus = 8.0;
+  float bonus  = Config::validHitSlope_*nfoundhits + Config::validHitBonus_;
+  float penalty = Config::missingHitPenalty_;
+  if(pt < 0.9){
+    penalty += 0.5*Config::missingHitPenalty_; 
+    bonus = std::min(bonus, maxBonus);
   }
-  if (seedtype==2 || seedtype==3) {
-    if (nfoundhits<=8) {
-      score_ -= 0.06f*(Config::validHitBonus_)*nfoundhits;
-    } else if (nfoundhits>12) {
-      score_ += 0.08f*(Config::validHitBonus_)*nfoundhits;
-    }
-  } else {
-    if (nfoundhits<=8) {
-      score_ -= 0.15f*(Config::validHitBonus_)*nfoundhits;
-    } else if (nfoundhits>12) {
-      score_ += 0.20f*(Config::validHitBonus_)*nfoundhits;
-    }
-  }
+  float score_ = bonus*nfoundhits + Config::overlapHitBonus_*noverlaphits - penalty*nmisshits - Config::tailMissingHitPenalty_*ntailholes - chi2;
   return score_;
 }
 
-inline float getScoreCand(const Track& cand1)
-{
-  unsigned int seedtype = cand1.getSeedTypeForRanking();
-  int nfoundhits = cand1.nFoundHits();
-  int noverlaphits = cand1.nOverlapHits();
-  int nmisshits = cand1.nInsideMinusOneHits();
-  float pt = cand1.pT();
-  float chi2 = cand1.chi2();
-  // Do not allow for chi2<0 in score calculation
-  if(chi2<0) chi2=0.f;
-  return getScoreCalc(seedtype,nfoundhits,noverlaphits,nmisshits,chi2,pt);
-}
+ inline float getScoreCand(const Track& cand1, bool penalizeTailMissHits=false)
+ {
+   unsigned int seedtype = cand1.getSeedTypeForRanking();
+   int nfoundhits = cand1.nFoundHits();
+   int noverlaphits = cand1.nOverlapHits();
+   int nmisshits = cand1.nInsideMinusOneHits();
+   float ntailmisshits = penalizeTailMissHits ? cand1.nTailMinusOneHits() : 0; 
+   float pt = cand1.pT();
+   float chi2 = cand1.chi2();
+   // Do not allow for chi2<0 in score calculation  
+   if(chi2<0) chi2=0.f;
+   return getScoreCalc(seedtype,nfoundhits,ntailmisshits,noverlaphits,nmisshits,chi2,pt);
+ }
 
 inline float getScoreStruct(const IdxChi2List& cand1)
 {
   unsigned int seedtype = cand1.seedtype;
   int nfoundhits = cand1.nhits;
+  int ntailholes = cand1.ntailholes;
   int noverlaphits = cand1.noverlaps;
   int nmisshits = cand1.nholes;
   float pt = cand1.pt;
   float chi2 = cand1.chi2;
   // Do not allow for chi2<0 in score calculation
   if(chi2<0) chi2=0.f;
-  return getScoreCalc(seedtype,nfoundhits,noverlaphits,nmisshits,chi2,pt);
+  return getScoreCalc(seedtype,nfoundhits,ntailholes,noverlaphits,nmisshits,chi2,pt);
 }
 
 

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -443,17 +443,18 @@ inline bool sortByScoreTrackCand(const TrackCand & cand1, const TrackCand & cand
   return cand1.score() > cand2.score();
 }
 
-inline float getScoreCand(const TrackCand& cand1)
+inline float getScoreCand(const TrackCand& cand1, bool penalizeTailMissHits=false)
 {
   unsigned int seedtype = cand1.getSeedTypeForRanking();
   int nfoundhits   = cand1.nFoundHits();
   int noverlaphits = cand1.nOverlapHits();
   int nmisshits    = cand1.nInsideMinusOneHits();
+  float ntailmisshits = penalizeTailMissHits ? cand1.nTailMinusOneHits() : 0;
   float pt = cand1.pT();
   float chi2 = cand1.chi2();
   // Do not allow for chi2<0 in score calculation
   if (chi2 < 0) chi2 = 0.f;
-  return getScoreCalc(seedtype, nfoundhits, noverlaphits, nmisshits, chi2, pt);
+  return getScoreCalc(seedtype, nfoundhits,ntailmisshits, noverlaphits, nmisshits, chi2, pt);
 }
 
 

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -662,7 +662,7 @@ void MkFinder::FindCandidates(const LayerOfHits                   &layer_of_hits
             copy_out(newcand, itrack, iC);
 	    newcand.addHitIdx(hit_idx, layer_of_hits.layer_id(), chi2);
 	    newcand.setSeedTypeForRanking(SeedType(itrack, 0, 0));
-	    newcand.setScore(getScoreCand(newcand));
+	    newcand.setScore(getScoreCand(newcand, true));
             newcand.setOriginIndex(CandIdx(itrack, 0, 0));
 
             if (chi2 < Config::chi2CutOverlap)
@@ -713,7 +713,7 @@ void MkFinder::FindCandidates(const LayerOfHits                   &layer_of_hits
     copy_out(newcand, itrack, iP);
     newcand.addHitIdx(fake_hit_idx, layer_of_hits.layer_id(), 0.);
     newcand.setSeedTypeForRanking(SeedType(itrack, 0, 0));
-    newcand.setScore(getScoreCand(newcand));
+    newcand.setScore(getScoreCand(newcand, true));
     // Only relevant when we actually add a hit
     // newcand.setOriginIndex(CandIdx(itrack, 0, 0));
     tmp_candidates[SeedIdx(itrack, 0, 0) - offset].emplace_back(newcand);
@@ -796,6 +796,7 @@ void MkFinder::FindCandidatesCloneEngine(const LayerOfHits &layer_of_hits, CandC
           tmpList.hitIdx   = hit_idx;
           tmpList.module   = layer_of_hits.GetHit(hit_idx).detIDinLayer();
           tmpList.nhits    = NFoundHits(itrack,0,0) + 1;
+          tmpList.ntailholes= 0;
           tmpList.noverlaps= NOverlapHits(itrack,0,0);
           tmpList.nholes   = num_all_minus_one_hits(itrack);
           tmpList.seedtype = SeedType(itrack, 0, 0);
@@ -842,6 +843,7 @@ void MkFinder::FindCandidatesCloneEngine(const LayerOfHits &layer_of_hits, CandC
     tmpList.hitIdx   = fake_hit_idx;
     tmpList.module   = -1;
     tmpList.nhits    = NFoundHits(itrack,0,0);
+    tmpList.ntailholes= NTailMinusOneHits(itrack,0,0)+1;
     tmpList.noverlaps= NOverlapHits(itrack,0,0);
     tmpList.nholes   = num_inside_minus_one_hits(itrack);
     tmpList.seedtype = SeedType(itrack, 0, 0);


### PR DESCRIPTION
This is the new tuning for the candidate scoring after all of Pandora's Box, as described in slides presented on [February 19](https://indico.cern.ch/event/971170/contributions/4088757/attachments/2193594/3708015/tuningFeb2021.pdf) and [March 5](https://indico.cern.ch/event/971172/contributions/4088787/attachments/2202859/3726460/tuningMarch2021.pdf) and in the google doc [here](https://docs.google.com/spreadsheets/d/1nZJxZ4qMrmotxAenZhlcRQmvKVcVsm-7IV_n_MbvkKo/edit#gid=1882976983). 

The stable 2020 performance is [here](https://areinsvo.web.cern.ch/areinsvo/MkFit/PandorasBox/stable2020_benchmarks/).

The Pandora's Box performance (pretuning) is [here](https://areinsvo.web.cern.ch/areinsvo/MkFit/PandorasBox/PandorasBox_benchmarks/).

The new tuning results in this PR are [here](https://areinsvo.web.cern.ch/areinsvo/MkFit/PandorasBox/benchmarks_tune2_chi30/).
