### PR TITLE
Validation up to 9 iterations

### DIFF
--- a/Event.cc
+++ b/Event.cc
@@ -763,8 +763,9 @@ int Event::clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& 
 
   TrackVec &seeds = (seed_ptr != nullptr) ? *seed_ptr : seedTracks_;
   const int ns = seeds.size();
-  std::cout << "before seed cleaning "<< seeds.size()<<std::endl;
-
+  #ifdef DEBUG
+   std::cout << "before seed cleaning "<< seeds.size()<<std::endl;
+  #endif
   TrackVec cleanSeedTracks;
   cleanSeedTracks.reserve(ns);
   std::vector<bool> writetrack(ns, true);
@@ -895,9 +896,10 @@ int Event::clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& 
     }
   }
 #endif
-  
-  std::cout << "AFTER seed cleaning "<< seeds.size()<<std::endl;
 
+#ifdef DEBUG  
+  std::cout << "AFTER seed cleaning "<< seeds.size()<<std::endl;
+#endif
   return seeds.size();
 }
 

--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -111,7 +111,29 @@ namespace
       ip.chi2Cut          = 30; 
       ip.chi2CutOverlap   = 3.5;
       ip.pTCutOverlap     = 1;
-    }  
+    } 
+    else if (it == 7) //for the PixelLess and TobTec: maxcand 2 and 0 consecHoles
+    {   
+      ip.nlayers_per_seed = 3;
+      ip.maxCandsPerSeed  = 2;
+      ip.maxHolesPerCand  = 4;
+      ip.maxConsecHoles   = 0;
+      ip.chi2Cut          = 30; 
+      ip.chi2CutOverlap   = 3.5;
+      ip.pTCutOverlap     = 1;
+    }   
+    else if (it == 8)
+    {   
+      ip.nlayers_per_seed = 3;
+      ip.maxCandsPerSeed  = 2;
+      ip.maxHolesPerCand  = 0;
+      ip.maxConsecHoles   = 1;
+      ip.chi2Cut          = 30; 
+      ip.chi2CutOverlap   = 3.5;
+      ip.pTCutOverlap     = 1;
+    }   
+  
+ 
   }
 
   std::function<IterationConfig::partition_seeds_foo> PartitionSeeds0 =
@@ -227,7 +249,7 @@ namespace
     ti.set_eta_regions(0.9, 1.7, 2.45, false);
     ti.create_layers(18, 27, 27);
 
-    ii.resize(3);
+    ii.resize(9);
     ii[0].set_iteration_index_and_track_algorithm(0, (int) TrackBase::TrackAlgorithm::initialStep);
     ii[0].set_num_regions_layers(5, 72);
 
@@ -237,13 +259,40 @@ namespace
     SetupIterationParams(ii[0].m_params, 0);
     ii[0].m_partition_seeds = PartitionSeeds0;
 
-    ii[1].Clone(ii[0]);
+    ii[1].Clone(ii[0]); //added extra iterations with some preliminary setup
     SetupIterationParams(ii[1].m_params, 1);//3 seed hits is the only difference
     ii[1].set_iteration_index_and_track_algorithm(1, (int) TrackBase::TrackAlgorithm::highPtTripletStep);
-    ii[1].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.018, 0.018, 0.018, 0.05, 0.018, 0.05); //maybe have he parameters stored somewhere
+    ii[1].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.018, 0.018, 0.018, 0.05, 0.018, 0.05); 
+
     ii[2].Clone(ii[0]);
     ii[2].set_iteration_index_and_track_algorithm(2, (int) TrackBase::TrackAlgorithm::lowPtQuadStep);
-    ii[2].set_seed_cleaning_params(0.5, 0.018, 0.018, 0.018, 0.018, 0.05, 0.05, 0.05, 0.05);
+    ii[2].set_seed_cleaning_params(0.5, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
+     
+    ii[3].Clone(ii[0]);
+    ii[3].set_iteration_index_and_track_algorithm(3, (int) TrackBase::TrackAlgorithm::lowPtTripletStep);
+    ii[3].set_seed_cleaning_params(0.5, 0.0, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
+    
+    ii[4].Clone(ii[0]);
+    ii[4].set_iteration_index_and_track_algorithm(4, (int) TrackBase::TrackAlgorithm::detachedQuadStep);
+    ii[4].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
+    
+    ii[5].Clone(ii[0]);
+    ii[5].set_iteration_index_and_track_algorithm(5, (int) TrackBase::TrackAlgorithm::detachedTripletStep);
+    ii[5].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
+
+    ii[6].Clone(ii[0]);
+    ii[6].set_iteration_index_and_track_algorithm(6, (int) TrackBase::TrackAlgorithm::mixedTripletStep);
+    ii[6].set_seed_cleaning_params(2.0, 0.05, 0.05, 0.135, 0.135, 0.05, 0.05, 0.135, 0.135);
+    
+    ii[7].Clone(ii[0]);
+    ii[7].set_iteration_index_and_track_algorithm(7, (int) TrackBase::TrackAlgorithm::pixelLessStep);
+    ii[7].set_seed_cleaning_params(2.0, 0.37, 0.37, 0.37, 0.37, 0.37, 0.37, 0.37, 0.37);
+    SetupIterationParams(ii[7].m_params, 7);
+    
+    ii[8].Clone(ii[0]);
+    ii[8].set_iteration_index_and_track_algorithm(8, (int) TrackBase::TrackAlgorithm::tobTecStep);
+    ii[8].set_seed_cleaning_params(2.0, 0.37, 0.37, 0.37, 0.37, 0.37, 0.37, 0.37, 0.37);    
+    SetupIterationParams(ii[8].m_params, 8);
 
     if (verbose)
     {

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -352,21 +352,24 @@ double runBuildingTestPlexCloneEngine(Event& ev, const EventOfHits &eoh, MkBuild
 // And if we care about doing too muich work for seeds that will never get processed.
 //==============================================================================
 
-double runBtbCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuilder& builder)
+double runBtbCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuilder& builder, unsigned int n)
 {
   double ttime = 0;
-  
+  if (n<=0) return ttime; //at least one iter by default
+
   const bool validation_on = (Config::sim_val || Config::quality_val);
   
   TrackVec seeds_used;
   TrackVec seeds1;
+   
+  unsigned int algorithms[]={ 4,22,23,5,24,7,8,9,10 }; //9 iterations
 
   if (validation_on) 
   {
     for (auto &s : ev.seedTracks_)
     {
-      if (s.algoint()==4 || s.algoint()==22 || s.algoint()==23) //keep seeds you want to process later
-        seeds1.push_back(s);
+      //keep seeds form the first n iterations for processing
+      if ( std::find(algorithms, algorithms+n, s.algoint())!=algorithms+n  ) seeds1.push_back(s);
     }
     ev.seedTracks_.swap(seeds1);//necessary for the validation - PrepareSeeds
     ev.relabel_bad_seedtracks();//necessary for the validation - PrepareSeeds
@@ -374,7 +377,7 @@ double runBtbCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuilder& builder)
   
   IterationMaskIfc mask_ifc;
 
-  for (int it = 0; it <= 2; ++it)
+  for (int it = 0; it <= n-1; ++it)
   {
     // MIMI - to disable hit-masks, pass nullptr in place of &mask_ifc to job
     // and optionally comment out ev.fill_hitmask_bool_vectors() call.

--- a/mkFit/buildtestMPlex.h
+++ b/mkFit/buildtestMPlex.h
@@ -16,7 +16,7 @@ double runBuildingTestPlexBestHit    (Event& ev, const EventOfHits &eoh, MkBuild
 double runBuildingTestPlexStandard   (Event& ev, const EventOfHits &eoh, MkBuilder& builder);
 double runBuildingTestPlexCloneEngine(Event& ev, const EventOfHits &eoh, MkBuilder& builder);
 
-double runBtbCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuilder& builder);
+double runBtbCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuilder& builder, unsigned int n);
 
 // nullptr is a valid mask ... means no mask for these layers.
 void   run_OneIteration(const TrackerInfo& trackerInfo, const IterationConfig &itconf, const EventOfHits &eoh,

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -313,7 +313,7 @@ void test_standard()
           // t_cur[0] = (g_run_fit_std) ? runFittingTestPlex(ev, plex_tracks) : 0;
           t_cur[1] = (g_run_build_all || g_run_build_bh)  ? runBuildingTestPlexBestHit(ev, eoh, mkb) : 0;
           t_cur[3] = (g_run_build_all || g_run_build_ce)  ? runBuildingTestPlexCloneEngine(ev, eoh, mkb) : 0;
-          t_cur[4] = (g_run_build_all || g_run_build_mimi)? runBtbCe_MultiIter(ev, eoh, mkb) : 0;
+          t_cur[4] = (g_run_build_all || g_run_build_mimi)? runBtbCe_MultiIter(ev, eoh, mkb, Config::nItersCMSSW) : 0;
           if (g_run_build_all || g_run_build_cmssw) runBuildingTestPlexDumbCMSSW(ev, eoh, mkb);
           t_cur[2] = (g_run_build_all || g_run_build_std) ? runBuildingTestPlexStandard(ev, eoh, mkb) : 0;
           if (g_run_build_ce){

--- a/val_scripts/validation-cmssw-benchmarks-multiiter.sh
+++ b/val_scripts/validation-cmssw-benchmarks-multiiter.sh
@@ -55,8 +55,9 @@ siminfo="--try-to-save-sim-info"
 bkfit="--backward-fit-pca"
 
 ## validation options: SIMVAL == sim tracks as reference, CMSSWVAL == cmssw tracks as reference
-SIMVAL="SIMVAL --sim-val ${siminfo} ${bkfit} ${style}"
-SIMVAL_SEED="SIMVALSEED --sim-val ${siminfo} ${bkfit} --mtv-require-seeds"
+SIMVAL="SIMVAL --sim-val ${siminfo} ${bkfit} ${style} --num-iters-cmssw 9"
+SIMVAL_SEED="SIMVALSEED --sim-val ${siminfo} ${bkfit} --mtv-require-seeds --num-iters-cmssw 9"
+
 declare -a vals=(SIMVAL SIMVAL_SEED)
 
 ## plotting options
@@ -68,12 +69,24 @@ SIMPLOT22="SIMVAL iter22 0 22 0"
 SIMPLOTSEED22="SIMVALSEED iter22 0 22 0"
 SIMPLOT23="SIMVAL iter23 0 23 0"
 SIMPLOTSEED23="SIMVALSEED iter23 0 23 0"
+SIMPLOT5="SIMVAL iter5 0 5 0"
+SIMPLOTSEED5="SIMVALSEED iter5 0 5 0"
+SIMPLOT24="SIMVAL iter24 0 24 0"
+SIMPLOTSEED24="SIMVALSEED iter24 0 24 0"
+SIMPLOT7="SIMVAL iter7 0 7 0"
+SIMPLOTSEED7="SIMVALSEED iter7 0 7 0"
+SIMPLOT8="SIMVAL iter8 0 8 0"
+SIMPLOTSEED8="SIMVALSEED iter8 0 8 0"
+SIMPLOT9="SIMVAL iter9 0 9 0"
+SIMPLOTSEED9="SIMVALSEED iter9 0 9 0"
+SIMPLOT10="SIMVAL iter10 0 10 0"
+SIMPLOTSEED10="SIMVALSEED iter10 0 10 0"
 
-declare -a plots=(SIMPLOT4 SIMPLOTSEED4 SIMPLOT22 SIMPLOTSEED22 SIMPLOT23 SIMPLOTSEED23 SIMPLOT SIMPLOTSEED)
+declare -a plots=(SIMPLOT4 SIMPLOTSEED4 SIMPLOT22 SIMPLOTSEED22 SIMPLOT23 SIMPLOTSEED23 SIMPLOT5 SIMPLOTSEED5 SIMPLOT24 SIMPLOTSEED24 SIMPLOT7 SIMPLOTSEED7 SIMPLOT8 SIMPLOTSEED8 SIMPLOT9 SIMPLOTSEED9 SIMPLOT10 SIMPLOTSEED10)
 
 ## special cmssw dummy build
-CMSSW="CMSSW cmssw SIMVAL --sim-val-for-cmssw ${siminfo} --read-cmssw-tracks ${style} --num-iters-cmssw 3"
-CMSSW2="CMSSW cmssw SIMVALSEED --sim-val-for-cmssw ${siminfo} --read-cmssw-tracks --mtv-require-seeds --num-iters-cmssw 3"
+CMSSW="CMSSW cmssw SIMVAL --sim-val-for-cmssw ${siminfo} --read-cmssw-tracks ${style} --num-iters-cmssw 9"
+CMSSW2="CMSSW cmssw SIMVALSEED --sim-val-for-cmssw ${siminfo} --read-cmssw-tracks --mtv-require-seeds --num-iters-cmssw 9"
 
 ###############
 ## Functions ##

--- a/web/collectBenchmarks-multi.sh
+++ b/web/collectBenchmarks-multi.sh
@@ -21,8 +21,8 @@ declare -a val_builds=(MIMI)
 ######################################
 
 # Make SimTrack Validation directories
-simdir=("SIMVAL_MTV" "SIMVAL_MTV_SEED" "SIMVAL_MTV_iter4" "SIMVAL_MTV_SEED_iter4" "SIMVAL_MTV_iter22" "SIMVAL_MTV_SEED_iter22" "SIMVAL_MTV_iter23" "SIMVAL_MTV_SEED_iter23")
-simval=("SIMVAL" "SIMVALSEED" "SIMVAL_iter4" "SIMVALSEED_iter4" "SIMVAL_iter22" "SIMVALSEED_iter22" "SIMVAL_iter23" "SIMVALSEED_iter23" )
+simdir=("SIMVAL_MTV_iter4" "SIMVAL_MTV_SEED_iter4" "SIMVAL_MTV_iter22" "SIMVAL_MTV_SEED_iter22" "SIMVAL_MTV_iter23" "SIMVAL_MTV_SEED_iter23" "SIMVAL_MTV_iter5" "SIMVAL_MTV_SEED_iter5" "SIMVAL_MTV_iter24" "SIMVAL_MTV_SEED_iter24" "SIMVAL_MTV_iter7" "SIMVAL_MTV_SEED_iter7" "SIMVAL_MTV_iter8" "SIMVAL_MTV_SEED_iter8" "SIMVAL_MTV_iter9" "SIMVAL_MTV_SEED_iter9" "SIMVAL_MTV_iter10" "SIMVAL_MTV_SEED_iter10" )
+simval=("SIMVAL_iter4" "SIMVALSEED_iter4" "SIMVAL_iter22" "SIMVALSEED_iter22" "SIMVAL_iter23" "SIMVALSEED_iter23" "SIMVAL_iter5" "SIMVALSEED_iter5" "SIMVAL_iter24" "SIMVALSEED_iter24" "SIMVAL_iter7" "SIMVALSEED_iter7" "SIMVAL_iter8" "SIMVALSEED_iter8" "SIMVAL_iter9" "SIMVALSEED_iter9" "SIMVAL_iter10" "SIMVALSEED_iter10" )
 
 for((i=0;i<${#simdir[@]};++i));do
 


### PR DESCRIPTION
Added standalone validation functionality for the first 9 iteration ( 6 pixel-based seed types + mixed triplet, pixelless, tobtec steps)

The configuration of the single iterations is preliminary and needs to be studied.

the number of iteration for runBtbCe_MultiIter and for cmssw comparison can be set using the option --num-iters-cmssw

the scripts to run the validation and collect the plots are updated to 9 iterations (it used to be 3)