### PR TITLE
Use original hit indices in mkFit hits and tracks.

### DIFF
--- a/mkFit/HitStructures.cc
+++ b/mkFit/HitStructures.cc
@@ -276,7 +276,8 @@ void LayerOfHits::EndRegistrationOfHits(bool build_original_to_internal_map)
 
     m_phi_bin_infos[q_bin][phi_bin].second++;
 
-    // m_hit_ranks[i] will never be used again ... use it to point to external index.
+    // m_hit_ranks[i] will never be used again ... use it to point to external/original index,
+    // as it does in standalone case.
     m_hit_ranks[i] = k;
   }
 
@@ -285,7 +286,7 @@ void LayerOfHits::EndRegistrationOfHits(bool build_original_to_internal_map)
     if (m_max_ext_idx - m_min_ext_idx + 1 > 8*size)
     {
       // If this happens we might:
-      // a) Really use external indices for everything.
+      // a) Use external indices for everything. -- *** We are now. ***
       // b) Build these maps for seeding layers only.
       // c) Have a flag in hit-on-track that tells us if the hit index has been remapped,
       //    essentially, if it is a seed hit. This might not be too stupid anyway.

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -231,7 +231,7 @@ public:
   void  RegisterHit(int idx);
   void  EndRegistrationOfHits(bool build_original_to_internal_map);
 
-  // Use this to map original indices to sorted internal ones.
+  // Use this to map original indices to sorted internal ones. m_ext_idcs needs to be initialized.
   int   GetHitIndexFromOriginal(int i) const { return m_ext_idcs[i - m_min_ext_idx]; }
   // Use this to remap internal hit index to external one.
   int   GetOriginalHitIndex(int i) const { return m_hit_ranks[i]; }
@@ -240,12 +240,8 @@ public:
   const Hit& GetHit(int i) const { return m_hits[i]; }
   const Hit* GetHitArray() const { return m_hits; }
 #else
-  const Hit& GetHit(int i) const { return (*m_ext_hits)[m_hit_ranks[i]]; }
-  const Hit* GetHitArray() const { return & (*m_ext_hits)[0]; }
-
-  // This would also be possible for COPY_SORTED_HITS, but somebody must guarantee they stay const
-  // after suck in -- and we need to add m_ext_hits for that case, too.
-  const Hit& GetHitWithOriginalIndex(int i) const { return (*m_ext_hits)[i]; }
+  const Hit& GetHit(int i) const { return (*m_ext_hits)[i]; }
+  const Hit* GetHitArray() const { return m_ext_hits->data(); }
 #endif
 
   // void  SelectHitIndices(float q, float phi, float dq, float dphi, std::vector<int>& idcs, bool isForSeeding=false, bool dump=false);

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -584,126 +584,6 @@ inline void MkBuilder::fit_one_seed_set(TrackVec& seedtracks, int itrack, int en
 }
 */
 
-//------------------------------------------------------------------------------
-// Common functions for validation
-//------------------------------------------------------------------------------
-
-void MkBuilder::map_track_hits(TrackVec & tracks)
-{
-  // map hit indices from global m_event->layerHits_[i] to hit indices in
-  // structure m_event_of_hits.m_layers_of_hits[i].m_hits
-
-  const int max_layer = Config::nTotalLayers;
-
-  int max = 0;
-  int min = std::numeric_limits<int>::max();
-
-  std::vector<int> layer_has_hits(max_layer);
-  for (auto&& track : tracks)
-  {
-    for (int i = 0; i < track.nTotalHits(); ++i)
-    {
-      if (track.getHitIdx(i) >= 0)  ++layer_has_hits[track.getHitLyr(i)];
-    }
-  }
-
-  for (int ilayer = 0; ilayer < max_layer; ++ilayer)
-  {
-    if (layer_has_hits[ilayer])
-    {
-      const auto  &loh  = m_job->m_event_of_hits.m_layers_of_hits[ilayer];
-      const auto   size = m_event->layerHits_[ilayer].size();
-
-      for (size_t index = 0; index < size; ++index)
-      {
-        const auto mcHitID = loh.GetHit(index).mcHitID();
-        min = std::min(min, mcHitID);
-        max = std::max(max, mcHitID);
-      }
-    }
-  }
-
-  std::vector<int> trackHitMap(max-min+1);
-
-  for (int ilayer = 0; ilayer < max_layer; ++ilayer)
-  {
-    if (layer_has_hits[ilayer])
-    {
-      const auto  &loh  = m_job->m_event_of_hits.m_layers_of_hits[ilayer];
-      const auto   size = m_event->layerHits_[ilayer].size();
-
-      for (size_t index = 0; index < size; ++index)
-      {
-        trackHitMap[loh.GetHit(index).mcHitID()-min] = index;
-      }
-    }
-  }
-
-  for (auto&& track : tracks)
-  {
-    for (int i = 0; i < track.nTotalHits(); ++i)
-    {
-      int hitidx = track.getHitIdx(i);
-      int hitlyr = track.getHitLyr(i);
-      if (hitidx >= 0)
-      {
-        const auto & global_hit_vec = m_event->layerHits_[hitlyr];
-        track.setHitIdx(i, trackHitMap[global_hit_vec[hitidx].mcHitID()-min]);
-        // printf("YYY mapped %d/%d to %d\n", hitidx, hitlyr, trackHitMap[global_hit_vec[hitidx].mcHitID()-min]);
-      }
-    }
-  }
-}
-
-void MkBuilder::remap_track_hits(TrackVec & tracks)
-{
-  // map cand hit indices from hit indices in structure
-  // m_event_of_hits.m_layers_of_hits[i].m_hits to global m_event->layerHits_[i]
-
-  const int max_layer = Config::nTotalLayers;
-
-  int max = 0;
-  int min = std::numeric_limits<int>::max();
-
-  for (int ilayer = 0; ilayer < max_layer; ++ilayer)
-  {
-    const auto & global_hit_vec = m_event->layerHits_[ilayer];
-    const auto   size = global_hit_vec.size();
-    for (size_t index = 0; index < size; ++index)
-    {
-      const auto mcHitID = global_hit_vec[index].mcHitID();
-      min = std::min(min, mcHitID);
-      max = std::max(max, mcHitID);
-    }
-  }
-
-  std::vector<int> trackHitMap(max-min+1);
-
-  for (int ilayer = 0; ilayer < max_layer; ++ilayer)
-  {
-    const auto & global_hit_vec = m_event->layerHits_[ilayer];
-    const auto   size = global_hit_vec.size();
-    for (size_t index = 0; index < size; ++index)
-    {
-      trackHitMap[global_hit_vec[index].mcHitID()-min] = index;
-    }
-  }
-
-  for (auto&& track : tracks)
-  {
-    for (int i = 0; i < track.nTotalHits(); ++i)
-    {
-      int hitidx = track.getHitIdx(i);
-      int hitlyr = track.getHitLyr(i);
-      if (hitidx >= 0)
-      {
-        const auto & loh = m_job->m_event_of_hits.m_layers_of_hits[hitlyr];
-        track.setHitIdx(i, trackHitMap[loh.GetHit(hitidx).mcHitID() - min]);
-      }
-    }
-  }
-
-}
 
 //------------------------------------------------------------------------------
 // Non-ROOT validation
@@ -712,10 +592,6 @@ void MkBuilder::remap_track_hits(TrackVec & tracks)
 void MkBuilder::quality_val()
 {
   quality_reset();
-
-  // remap hits
-  // ZOIX remap_track_hits(m_event->seedTracks_);
-  // ZOIX remap_track_hits(m_event->candidateTracks_);
 
   std::map<int,int> cmsswLabelToPos;
   if (Config::dumpForPlots && Config::readCmsswTracks)
@@ -1050,17 +926,12 @@ void MkBuilder::root_val_dumb_cmssw()
 
 void MkBuilder::root_val()
 {
-  // remap hits first before prepping extras
-  // ZOIX remap_track_hits(m_event->seedTracks_);
-  // ZOIX remap_track_hits(m_event->candidateTracks_);
-
   // score the tracks
   score_tracks(m_event->seedTracks_);
   score_tracks(m_event->candidateTracks_);
 
   // deal with fit tracks
   if (Config::backwardFit){
-    // ZOIX remap_track_hits(m_event->fitTracks_);
     score_tracks(m_event->fitTracks_);
   }
   else m_event->fitTracks_ = m_event->candidateTracks_;
@@ -1076,10 +947,6 @@ void MkBuilder::root_val()
 void MkBuilder::cmssw_export()
 {
   // get the tracks ready for export
-  // ZOIX remap_track_hits(m_event->candidateTracks_);
-  if(Config::backwardFit) {
-    // ZOIX remap_track_hits(m_event->fitTracks_);
-  }
   // prep_(reco)tracks doesn't actually do anything useful for CMSSW.
   // We don't need the extra (seed index is obtained via canidate
   // track label()), and sorting the hits by layer is actually
@@ -1301,8 +1168,6 @@ void MkBuilder::PrepareSeeds()
     // create_seeds_from_sim_tracks();
 
     seed_post_cleaning(m_event->seedTracks_, true, true);
-
-    // ZOIX map_track_hits(m_event->seedTracks_);
   }
   else if (Config::seedInput == cmsswSeeds)
   {
@@ -1361,9 +1226,6 @@ void MkBuilder::PrepareSeeds()
 
     // in rare corner cases, seed tracks could be fully cleaned out: skip mapping if so
     if (m_event->seedTracks_.empty()) return;
-
-    // map seed track hits into layer_of_hits
-    // ZOIX map_track_hits(m_event->seedTracks_);
   }
   else if (Config::seedInput == findSeeds)
   {

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -703,31 +703,6 @@ void MkBuilder::remap_track_hits(TrackVec & tracks)
     }
   }
 
-  // Matti ... this can now be just something like this (not tested):
-  /*
-  for (auto&& track : tracks)
-  {
-    for (int i = 0; i < track.nTotalHits(); ++i)
-    {
-      int hitidx = track.getHitIdx(i);
-      int hitlyr = track.getHitLyr(i);
-      if (hitidx >= 0)
-      {
-        const auto & loh = m_event_of_hits.m_layers_of_hits[hitlyr];
-        track.setHitIdx(i, loh.GetOriginalHitIndex(hitidx));
-      }
-    }
-  }
-  */
-  // Note that the indices after this are correct CMSSW "large-vector" indices.
-  // So no hit/layer mapping code in CMSSW producer is needed.
-  //
-  // We could really store original indices into HitOnTrack.index
-  // from the start. One just needs to be careful when getting hits in backwards fit,
-  // to use (a currently non-existent) LayerOfHits::GetHitWithOriginalIndex(hot.index)
-  //
-  // Further, somebody should walk over quite a bit of validation code that is
-  // rather involved doing such remappings.
 }
 
 //------------------------------------------------------------------------------
@@ -739,8 +714,8 @@ void MkBuilder::quality_val()
   quality_reset();
 
   // remap hits
-  remap_track_hits(m_event->seedTracks_);
-  remap_track_hits(m_event->candidateTracks_);
+  // ZOIX remap_track_hits(m_event->seedTracks_);
+  // ZOIX remap_track_hits(m_event->candidateTracks_);
 
   std::map<int,int> cmsswLabelToPos;
   if (Config::dumpForPlots && Config::readCmsswTracks)
@@ -1076,8 +1051,8 @@ void MkBuilder::root_val_dumb_cmssw()
 void MkBuilder::root_val()
 {
   // remap hits first before prepping extras
-  remap_track_hits(m_event->seedTracks_);
-  remap_track_hits(m_event->candidateTracks_);
+  // ZOIX remap_track_hits(m_event->seedTracks_);
+  // ZOIX remap_track_hits(m_event->candidateTracks_);
 
   // score the tracks
   score_tracks(m_event->seedTracks_);
@@ -1085,7 +1060,7 @@ void MkBuilder::root_val()
 
   // deal with fit tracks
   if (Config::backwardFit){
-    remap_track_hits(m_event->fitTracks_);
+    // ZOIX remap_track_hits(m_event->fitTracks_);
     score_tracks(m_event->fitTracks_);
   }
   else m_event->fitTracks_ = m_event->candidateTracks_;
@@ -1101,9 +1076,9 @@ void MkBuilder::root_val()
 void MkBuilder::cmssw_export()
 {
   // get the tracks ready for export
-  remap_track_hits(m_event->candidateTracks_);
+  // ZOIX remap_track_hits(m_event->candidateTracks_);
   if(Config::backwardFit) {
-    remap_track_hits(m_event->fitTracks_);
+    // ZOIX remap_track_hits(m_event->fitTracks_);
   }
   // prep_(reco)tracks doesn't actually do anything useful for CMSSW.
   // We don't need the extra (seed index is obtained via canidate
@@ -1327,7 +1302,7 @@ void MkBuilder::PrepareSeeds()
 
     seed_post_cleaning(m_event->seedTracks_, true, true);
 
-    map_track_hits(m_event->seedTracks_);
+    // ZOIX map_track_hits(m_event->seedTracks_);
   }
   else if (Config::seedInput == cmsswSeeds)
   {
@@ -1388,7 +1363,7 @@ void MkBuilder::PrepareSeeds()
     if (m_event->seedTracks_.empty()) return;
 
     // map seed track hits into layer_of_hits
-    map_track_hits(m_event->seedTracks_);
+    // ZOIX map_track_hits(m_event->seedTracks_);
   }
   else if (Config::seedInput == findSeeds)
   {

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -383,10 +383,12 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
         {
           // MT: Access into m_hit_zs and m_hit_phis is 1% run-time each.
 
-          if (m_iteration_hit_mask && (*m_iteration_hit_mask)[L.GetOriginalHitIndex(hi)])
+          int hi_orig = L.GetOriginalHitIndex(hi);
+
+          if (m_iteration_hit_mask && (*m_iteration_hit_mask)[hi_orig])
           {
             // printf("Yay, denying masked hit on layer %d, hi %d, orig idx %d\n",
-            //        L.m_layer_info->m_layer_id, hi, L.GetOriginalHitIndex(hi));
+            //        L.m_layer_info->m_layer_id, hi, hi_orig);
             continue;
           }
 
@@ -412,14 +414,14 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
             // Avi says we should have *minimal* search windows per layer.
             // Also ... if bins are sufficiently small, we do not need the extra
             // checks, see above.
-            if (L.GetHit(hi).mcHitID() == -7)
+            if (L.GetHit(hi_orig).mcHitID() == -7)
             {
               //ARH: This will need a better treatment but works for now
               XWsrResult[itrack].m_in_gap = true;
             }
             else
             {
-              XHitArr.At(itrack, XHitSize[itrack]++, 0) = hi;
+              XHitArr.At(itrack, XHitSize[itrack]++, 0) = hi_orig;
             }
           }
           else
@@ -433,7 +435,7 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
 
             if (XHitSize[itrack] < MPlexHitIdxMax)
             {
-              XHitArr.At(itrack, XHitSize[itrack]++, 0) = hi;
+              XHitArr.At(itrack, XHitSize[itrack]++, 0) = hi_orig;
             }
           }
         } //hi

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -357,8 +357,8 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
     const float dphi = dphiv[itrack];
     const float dq   = dqv[itrack];
 
-    dprintf("  %2d: %6.3f %6.3f %6.6f %7.5f %3d %3d %4d %4d\n",
-             itrack, q, phi, dq, dphi, qb1, qb2, pb1, pb2);
+    dprintf("  %2d/%2d: %6.3f %6.3f %6.6f %7.5f %3d %3d %4d %4d\n",
+            L.layer_id(), itrack, q, phi, dq, dphi, qb1, qb2, pb1, pb2);
 
     // MT: One could iterate in "spiral" order, to pick hits close to the center.
     // http://stackoverflow.com/questions/398299/looping-in-a-spiral

--- a/mkFit/MkStdSeqs.cc
+++ b/mkFit/MkStdSeqs.cc
@@ -57,7 +57,7 @@ void Cmssw_LoadHits_End(EventOfHits &eoh)
 {
   for (auto &&l : eoh.m_layers_of_hits)
   {
-    l.EndRegistrationOfHits(true);
+    l.EndRegistrationOfHits(false);
   }
 }
 

--- a/mkFit/MkStdSeqs.h
+++ b/mkFit/MkStdSeqs.h
@@ -15,6 +15,9 @@ namespace StdSeq
 
     void Cmssw_LoadHits_Begin(EventOfHits &eoh, const std::vector<const HitVec*> &orig_hitvectors);
     void Cmssw_LoadHits_End(EventOfHits &eoh);
+
+    // Not used anymore. Left here if we want to experiment again with
+    // COPY_SORTED_HITS in class LayerOfHits.
     void Cmssw_Map_TrackHitIndices(const EventOfHits &eoh, TrackVec &seeds);
     void Cmssw_ReMap_TrackHitIndices(const EventOfHits &eoh, TrackVec &out_tracks);
 

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -409,7 +409,7 @@ double runBtbCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuilder& builder,
     ev.clean_cms_seedtracks_iter(&seeds, Config::ItrInfo[it]);
 
     builder.seed_post_cleaning(seeds, true, true);
-    builder.map_track_hits(seeds);
+    // ZOIX builder.map_track_hits(seeds);
     for (auto &s : seeds) assignSeedTypeForRanking(s);
 
     builder.find_tracks_load_seeds(seeds);
@@ -524,7 +524,7 @@ void run_OneIteration(const TrackerInfo& trackerInfo, const IterationConfig &itc
   // the track parameter coordinate transformation.
   builder.seed_post_cleaning(seeds, true, true);
 
-  StdSeq::Cmssw_Map_TrackHitIndices(eoh, seeds);
+  // ZOIX StdSeq::Cmssw_Map_TrackHitIndices(eoh, seeds);
 
   for (auto &s : seeds) assignSeedTypeForRanking(s);
 
@@ -548,7 +548,7 @@ void run_OneIteration(const TrackerInfo& trackerInfo, const IterationConfig &itc
     // builder.export_best_comb_cands(out_tracks);
   }
 
-  StdSeq::Cmssw_ReMap_TrackHitIndices(eoh, out_tracks);
+  // ZOIX StdSeq::Cmssw_ReMap_TrackHitIndices(eoh, out_tracks);
 
   if (do_remove_duplicates)
   {

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -409,7 +409,7 @@ double runBtbCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuilder& builder,
     ev.clean_cms_seedtracks_iter(&seeds, Config::ItrInfo[it]);
 
     builder.seed_post_cleaning(seeds, true, true);
-    // ZOIX builder.map_track_hits(seeds);
+
     for (auto &s : seeds) assignSeedTypeForRanking(s);
 
     builder.find_tracks_load_seeds(seeds);
@@ -524,8 +524,6 @@ void run_OneIteration(const TrackerInfo& trackerInfo, const IterationConfig &itc
   // the track parameter coordinate transformation.
   builder.seed_post_cleaning(seeds, true, true);
 
-  // ZOIX StdSeq::Cmssw_Map_TrackHitIndices(eoh, seeds);
-
   for (auto &s : seeds) assignSeedTypeForRanking(s);
 
   builder.find_tracks_load_seeds(seeds);
@@ -547,8 +545,6 @@ void run_OneIteration(const TrackerInfo& trackerInfo, const IterationConfig &itc
     // builder.BackwardFit();
     // builder.export_best_comb_cands(out_tracks);
   }
-
-  // ZOIX StdSeq::Cmssw_ReMap_TrackHitIndices(eoh, out_tracks);
 
   if (do_remove_duplicates)
   {


### PR DESCRIPTION
Mapping of seed hits and re-mapping of result tracks is not needed.

Note, mapping/remapping functions are still in the code (for standalone and cmssw). The calls to these functions have been commented out with // ZOIX prefix. I could in principle remove those functions and calls as I don't think we will be going back to copying of hits into internal vectors.

Results are identical on a limited comparison with quality validation.

If somebody whose access to phi3 has been re-established could run the validation it would be appreciated.
