### PR TITLE
Implement saving of configuration to a set of JSON files, one per iteration.

### DIFF
--- a/Config.cc
+++ b/Config.cc
@@ -102,7 +102,8 @@ namespace Config
   bool        json_patch_dump_before = false;
   bool        json_patch_dump_after  = false;
   bool        json_patch_verbose     = false;
-  std::string json_patch_filename;
+  std::vector<std::string> json_patch_filenames;
+  std::string              json_save_iters_fname_fmt;
 
   void RecalculateDependentConstants()
   {

--- a/Config.cc
+++ b/Config.cc
@@ -99,11 +99,13 @@ namespace Config
   bool  backwardFit = false;
   bool  includePCA = false;
 
-  bool        json_patch_dump_before = false;
-  bool        json_patch_dump_after  = false;
-  bool        json_patch_verbose     = false;
+  bool        json_dump_before = false;
+  bool        json_dump_after  = false;
+  bool        json_verbose     = false;
   std::vector<std::string> json_patch_filenames;
+  std::vector<std::string> json_load_filenames;
   std::string              json_save_iters_fname_fmt;
+  bool        json_save_iters_include_iter_info_preamble = false;
 
   void RecalculateDependentConstants()
   {

--- a/Config.h
+++ b/Config.h
@@ -399,11 +399,13 @@ namespace Config
 
   // ================================================================
 
-  extern bool        json_patch_dump_before;
-  extern bool        json_patch_dump_after;
-  extern bool        json_patch_verbose;
+  extern bool        json_dump_before;
+  extern bool        json_dump_after;
+  extern bool        json_verbose;
   extern std::vector<std::string> json_patch_filenames;
+  extern std::vector<std::string> json_load_filenames;
   extern std::string              json_save_iters_fname_fmt;
+  extern bool        json_save_iters_include_iter_info_preamble;
 
   // ================================================================
 

--- a/Config.h
+++ b/Config.h
@@ -402,7 +402,8 @@ namespace Config
   extern bool        json_patch_dump_before;
   extern bool        json_patch_dump_after;
   extern bool        json_patch_verbose;
-  extern std::string json_patch_filename;
+  extern std::vector<std::string> json_patch_filenames;
+  extern std::string              json_save_iters_fname_fmt;
 
   // ================================================================
 

--- a/Track.cc
+++ b/Track.cc
@@ -100,6 +100,25 @@ bool TrackBase::hasSillyValues(bool dump, bool fix, const char* pref)
   return is_silly;
 }
 
+const char* TrackBase::algoint_to_cstr(int algo)
+{
+  static const char* names[] = { "undefAlgorithm", "ctf", "duplicateMerge",
+    "cosmics", "initialStep", "lowPtTripletStep", "pixelPairStep", "detachedTripletStep",
+    "mixedTripletStep", "pixelLessStep", "tobTecStep", "jetCoreRegionalStep", "conversionStep",
+    "muonSeededStepInOut", "muonSeededStepOutIn", "outInEcalSeededConv", "inOutEcalSeededConv",
+    "nuclInter", "standAloneMuon", "globalMuon", "cosmicStandAloneMuon", "cosmicGlobalMuon",
+    "highPtTripletStep", "lowPtQuadStep", "detachedQuadStep", "reservedForUpgrades1",
+    "reservedForUpgrades2", "bTagGhostTracks", "beamhalo", "gsf", "hltPixel", "hltIter0",
+    "hltIter1", "hltIter2", "hltIter3", "hltIter4", "hltIterX", "hiRegitMuInitialStep",
+    "hiRegitMuLowPtTripletStep", "hiRegitMuPixelPairStep", "hiRegitMuDetachedTripletStep",
+    "hiRegitMuMixedTripletStep", "hiRegitMuPixelLessStep", "hiRegitMuTobTecStep",
+    "hiRegitMuMuonSeededStepInOut", "hiRegitMuMuonSeededStepOutIn", "algoSize" };
+
+    if (algo < 0 || algo >= (int) TrackAlgorithm::algoSize) return names[0];
+    return names[algo];
+}
+
+
 //==============================================================================
 // Track
 //==============================================================================

--- a/Track.h
+++ b/Track.h
@@ -341,6 +341,8 @@ public:
   // bool isStopped() const { return status_.stopped; }
   // void setStopped()      { status_.stopped = true; }
 
+  static const char* algoint_to_cstr(int algo);
+
   // ------------------------------------------------------------------------
 
 protected:

--- a/mkFit/IterationConfig.h
+++ b/mkFit/IterationConfig.h
@@ -262,6 +262,22 @@ public:
 
 class ConfigJsonPatcher
 {
+public:
+  struct PatchReport
+  {
+    int n_files         = 0;
+    int n_json_entities = 0;
+    int n_replacements  = 0;
+
+    void inc_counts(int f, int e, int r)
+    {
+      n_files         += f;
+      n_json_entities += e;
+      n_replacements  += r;
+    }
+  };
+
+private:
   nlohmann::json *m_json    = nullptr;
   nlohmann::json *m_current = nullptr;
 
@@ -301,7 +317,10 @@ public:
   std::string dump(int indent=2);
 };
 
-void ConfigJson_Patch_File(IterationsInfo &its_info, const std::string &fname);
+ConfigJsonPatcher::PatchReport
+ConfigJson_Patch_File(IterationsInfo &its_info, const std::vector<std::string> &fnames);
+
+void ConfigJson_Save_Iterations(IterationsInfo &its_info, const std::string &fname_fmt);
 
 void ConfigJson_Test_Direct(IterationConfig &it_cfg);
 void ConfigJson_Test_Patcher(IterationConfig &it_cfg);

--- a/mkFit/IterationConfig.h
+++ b/mkFit/IterationConfig.h
@@ -275,6 +275,13 @@ public:
       n_json_entities += e;
       n_replacements  += r;
     }
+    void inc_counts(const PatchReport& pr)
+    {
+      n_files         += pr.n_files;
+      n_json_entities += pr.n_json_entities;
+      n_replacements  += pr.n_replacements;
+    }
+    void reset() { n_files = n_json_entities = n_replacements  = 0; }
   };
 
 private:
@@ -317,10 +324,26 @@ public:
   std::string dump(int indent=2);
 };
 
-ConfigJsonPatcher::PatchReport
-ConfigJson_Patch_File(IterationsInfo &its_info, const std::vector<std::string> &fnames);
+// Patch IterationsInfo from a vector of files.
+// Assumes patch files include iteration-info preambles, i.e., they
+// were saved with include_iter_info_preamble=true.
+// If report is non-null counts are added to existing object.
+void             ConfigJson_Patch_Files(IterationsInfo &its_info, const std::vector<std::string> &fnames,
+                                       ConfigJsonPatcher::PatchReport *report=nullptr);
 
-void ConfigJson_Save_Iterations(IterationsInfo &its_info, const std::string &fname_fmt);
+// Load a single iteration from JSON file.
+// Searches for a match between m_algorithm in its_info and in JSON file to decide
+// which IterationConfig it will load over.
+// Assumes JSON file has been saved WITHOUT iteration-info preamble.
+// Returns reference to the selected IterationConfig.
+// If report is non-null counts are added to existing object.
+IterationConfig& ConfigJson_Load_File(IterationsInfo &its_info, const std::string &fname,
+                                      ConfigJsonPatcher::PatchReport *report=nullptr);
+
+void ConfigJson_Save_Iterations(IterationsInfo &its_info, const std::string &fname_fmt,
+                                bool include_iter_info_preamble);
+
+void ConfigJson_Dump(IterationsInfo &its_info);
 
 void ConfigJson_Test_Direct(IterationConfig &it_cfg);
 void ConfigJson_Test_Patcher(IterationConfig &it_cfg);

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -48,12 +48,21 @@ void initGeom()
 
   TrackerInfo::ExecTrackerInfoCreatorPlugin(Config::geomPlugin, Config::TrkInfo, Config::ItrInfo);
 
-  if ( ! Config::json_patch_filename.empty())
+  if ( ! Config::json_patch_filenames.empty())
   {
-    ConfigJson_Patch_File(Config::ItrInfo, Config::json_patch_filename);
+    auto report = ConfigJson_Patch_File(Config::ItrInfo, Config::json_patch_filenames);
+
+    printf("mkFit.cc/%s() read %d JSON entities from %d files, replaced %d parameters.\n",
+           __func__, report.n_json_entities, report.n_files, report.n_replacements);
+
   }
 
-  // Test functions for 
+  if ( ! Config::json_save_iters_fname_fmt.empty())
+  {
+    ConfigJson_Save_Iterations(Config::ItrInfo, Config::json_save_iters_fname_fmt);
+  }
+
+  // Test functions for ConfigJsonPatcher
   // ConfigJson_Test_Direct (Config::ItrInfo[0]);
   // ConfigJson_Test_Patcher(Config::ItrInfo[0]);
 
@@ -594,6 +603,9 @@ int main(int argc, const char *argv[])
 	"\n----------------------------------------------------------------------------------------------------------\n\n"
   "JSON config patcher options:\n\n"
   "  --json-patch <filename>  patch iteration config from given JSON file (def: do not patch)\n"
+  "                           can be specified multiple times for several files\n"
+  "  --json-save-iterations <fname-fmt> save per iteration json files\n"
+  "                           %%d in fname-fmt gets replaced with iteration number\n"
   "  --json-patch-verbose     print each patch assignment as it is being made (def: %s)\n"
   "  --json-patch-dump-before print iteration config before patching (def: %s)\n"
   "  --json-patch-dump-after  print iteration config after  patching (def: %s)\n"
@@ -987,7 +999,12 @@ int main(int argc, const char *argv[])
     else if (*i == "--json-patch")
     {
       next_arg_or_die(mArgs, i);
-      Config::json_patch_filename = *i;
+      Config::json_patch_filenames.push_back(*i);
+    }
+    else if (*i == "--json-save-iterations")
+    {
+      next_arg_or_die(mArgs, i);
+      Config::json_save_iters_fname_fmt = *i;
     }
     else if (*i == "--json-patch-verbose")
     {


### PR DESCRIPTION
To export (%d MUST be present):
  `` ./mkFit --json-save-iterations mkfit-iteration-%d.json ``

To load a single file, e.g.:
  `` ./mkFit .... --json-patch mkfit-iteration-0-test.json ``

To load a set of files use shell, --json-patch must be given for every file:
  `` ./mkFit .... `for a in {0..8}; do echo --json-patch mkfit-iteration-$a.json; done` ``

From ./mkFit --help:
```
JSON config patcher options:
  --json-patch <filename>  patch iteration config from given JSON file (def: do not patch)
                           can be specified multiple times for several files
  --json-save-iterations <fname-fmt> save per iteration json files
                          %d in fname-fmt gets replaced with iteration number
  --json-patch-verbose     print each patch assignment as it is being made (def: false)
  --json-patch-dump-before print iteration config before patching (def: false)
  --json-patch-dump-after  print iteration config after  patching (def: false)
```