### PR TITLE
Remove USE_MATRIPLEX and remaining traces of MIC as C define and make variable

### DIFF
--- a/Config.cc
+++ b/Config.cc
@@ -23,7 +23,7 @@ namespace Config
   int   numThreadsFinder = 1;
   int   numThreadsEvents = 1;
   
-#if defined(__MIC__) || defined(__AVX512F__)
+#if defined(__AVX512F__)
   int   numThreadsSimulation = 60;
 #else
   int   numThreadsSimulation = 12;

--- a/Config.h
+++ b/Config.h
@@ -413,22 +413,21 @@ namespace Config
     return (Config::mag_b0*z*z + Config::mag_b1*z + Config::mag_c1)*(Config::mag_a*r*r + 1.f);
   }
 
-#ifdef USE_MATRIPLEX
 
-  #ifndef MPT_SIZE
-    #if defined(__MIC__) || defined(__AVX512F__)
-      #define MPT_SIZE 16
-    #elif defined(__AVX__) || defined(__AVX2__)
-      #define MPT_SIZE 8
-    #else
-      #define MPT_SIZE 8
-    #endif
+#ifndef MPT_SIZE
+  #if defined(__AVX512F__)
+    #define MPT_SIZE 16
+  #elif defined(__AVX__) || defined(__AVX2__)
+    #define MPT_SIZE 8
+  #elif defined(__SSE3__)
+    #define MPT_SIZE 4
+  #else
+    #define MPT_SIZE 8
   #endif
+#endif
 
-  #ifndef THREAD_BINDING
-  #define THREAD_BINDING spread
-  #endif
-
+#ifndef THREAD_BINDING
+#define THREAD_BINDING spread
 #endif
 
 };

--- a/Geoms/Makefile
+++ b/Geoms/Makefile
@@ -26,9 +26,6 @@ all: ${TGTS}
 %.so: %.o
 	${CXX} -shared -L../lib -lMicCore -o $@ $<
 
-%.om: %.cc %.d
-	${CXX} ${CPPFLAGS_NO_ROOT} ${CXXFLAGS} ${VEC_MIC} -c -o $@ $<
-
 ifeq ($(filter clean distclean, ${MAKECMDGOALS}),)
 include ${DEPS}
 endif

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CORE_OBJS := $(filter-out main.o, ${OBJS})
 
 AUTO_TGTS :=
 
-ifdef USE_MATRIPLEX
+# Begin Matriplex
 
 auto-matriplex:
 	${MAKE} -C Matriplex auto && touch $@
@@ -27,7 +27,7 @@ AUTO_TGTS += auto-matriplex
 
 ${DEPS}: auto-matriplex
 
-endif
+# End Matriplex
 
 ifeq ($(filter clean-local clean distclean, ${MAKECMDGOALS}),)
 include ${DEPS}

--- a/Makefile.config
+++ b/Makefile.config
@@ -7,7 +7,6 @@
 # This is also needed for icc as it uses gcc headers.
 
 # To build mkFit -- Matriplex Kalman Fit:
-# - enable USE_MATRIPLEX in section 5,
 # - cd mkFit; make (or make -C mkFit).
 
 
@@ -15,23 +14,25 @@
 # Configuration section
 ################################################################
 
-# -1. What to build
-# Define to build for AVX_512, the new mic (KNL) and latest generation Xeons.
+# -1. What to build - default is AVX
+# Define to build for AVX_512
 #AVX_512 := 1
 # Define to build for AVX2
 #AVX2    := 1
+# Define to build for SSE3
+#SSE3 := 1
 
 # 0. Use gcc-5 from MacPorts on OSX
 # OSXGCC5    := 1
 # Use clang from MacPorts on OSX
 # OSXMPCLANG   := 1
 
-# 1. Use ROOT or not (never used on MIC)
+# 1. Use ROOT or not
 # Comment out to disable root ("1" is not relevant)
 #WITH_ROOT := 1
 
 # 2. Use gcc (clang by default on mac) or icc
-# Comment out to force using standard c++. For mic only icc can be used.
+# Comment out to force using standard c++.
 ifdef INTEL_LICENSE_FILE
   # Define ICC to make it easier to switch to icpc
   ICC := icc
@@ -55,25 +56,22 @@ VEC_ICC  := -xHost -qopt-zmm-usage=high # -xcore-avx512
 else ifdef AVX2
 VEC_GCC  := -mavx2 -mfma
 VEC_ICC  := -mavx2 -mfma
+else ifdef SSE3
+VEC_GCC  := -msse3
+VEC_ICC  := -msse3
 else
 VEC_GCC  := -mavx # -fopt-info-vec-all
 VEC_ICC  := -mavx
 endif
-VEC_MIC  := -mmic
 
-# 5. Matriplex, intrinsics, vtune
-# Matriplex is required for build in mkFit/
-# Comment-out for matriplex, intrinsics (supported for MIC and AVX)
-USE_MATRIPLEX  := -DUSE_MATRIPLEX
+# 5. Matriplex intrinsics, vtune
+# Comment-out to enable intrinsics (supported for AVX512, AVX2 and AVX)
 USE_INTRINSICS := -DMPLEX_USE_INTRINSICS
 # To enforce given vector size (does not work with intrinsics!)
 #USE_INTRINSICS := -DMPT_SIZE=1
-
 USE_VTUNE_NOTIFY := 1
 
-# 6. MIC stuff is built when icc is the chosen compiler.
-# MIC build is always done without root.
-# Need to build root on MIC and figure out how to deploy it there.
+# 6. MIC stuff - obsolete
 
 # 7. OSX hack (is there a good way to detect clang?)
 # MT needs this on OSX-10.8, c++ -v
@@ -81,13 +79,6 @@ USE_VTUNE_NOTIFY := 1
 # OSX_CXXFLAGS := -stdlib=libc++
 # And with gcc-4.8.1 from cms we need this
 # OSX_LDFLAGS  := -lstdc++
-#
-# Note: there is a problem building with USE_MATRIPLEX on as there
-# was no __builtin_assume_aligned support in clang until recently:
-#   http://reviews.llvm.org/rL217349
-# It will probably take a while before this gets to osx / xcode.
-# If somebody is willing to test this we can try without this
-# but it was giving 50% speedup on icc.
 
 # 9. Check track state propagation for success, turns on simple
 # checks of filter convergence: used in SMatrix code mostly, still retain as toyMC propagation still uses this
@@ -115,11 +106,10 @@ WITH_TBB := 1
 # Derived settings
 ################################################################
 
-CPPFLAGS := -I. ${USE_MATRIPLEX} ${USE_INTRINSICS}
+CPPFLAGS := -I. ${USE_INTRINSICS}
 CXXFLAGS := -fPIC ${OPT} ${OSX_CXXFLAGS}
 
 LDFLAGS_HOST := 
-LDFLAGS_MIC  := -static-intel
 
 CPPFLAGS += ${USE_STATE_VALIDITY_CHECKS} ${USE_SCATTERING} ${USE_LINEAR_INTERPOLATION} ${ENDTOEND} ${INWARD_FIT} 
 
@@ -127,7 +117,6 @@ ifdef USE_VTUNE_NOTIFY
   ifdef VTUNE_AMPLIFIER_XE_2017_DIR
     CPPFLAGS     += -I$(VTUNE_AMPLIFIER_XE_2017_DIR)/include -DUSE_VTUNE_PAUSE
     LDFLAGS_HOST += -L$(VTUNE_AMPLIFIER_XE_2017_DIR)/lib64 -littnotify
-    LDFLAGS_MIC  += -L$(VTUNE_AMPLIFIER_XE_2017_DIR)/bin64/k1om -littnotify
   endif
 endif
 

--- a/Matriplex/GenMul.pm
+++ b/Matriplex/GenMul.pm
@@ -385,7 +385,7 @@ sub handle_all_zeros_ones
   {
     my @zo;
 
-    push @zo, "#ifdef MIC_INTRINSICS";
+    push @zo, "#ifdef AVX512_INTRINSICS";
 
     push @zo, "$S->{vectype} all_zeros = { " . join(", ", (0) x 16) . " };"
         if $zeros;

--- a/Matriplex/Matriplex.h
+++ b/Matriplex/Matriplex.h
@@ -104,7 +104,7 @@ public:
       }
    }
 
-#if defined(MIC_INTRINSICS)
+#if defined(AVX512_INTRINSICS)
 
    template<typename U>
    void SlurpIn(const T *arr, __m512i& vi, const U&, const int N_proc = N)

--- a/Matriplex/MatriplexCommon.h
+++ b/Matriplex/MatriplexCommon.h
@@ -16,18 +16,18 @@
 
 #if defined(MPLEX_USE_INTRINSICS)
   // This seems unnecessary: __AVX__ is usually defined for all higher ISA extensions
-  #if defined(__MIC__) || defined(__AVX__) || defined(__AVX512F__)
+  #if defined(__AVX__) || defined(__AVX512F__)
 
     #define MPLEX_INTRINSICS
 
   #endif
 
-  #if defined(__MIC__) || defined(__AVX512F__)
+  #if defined(__AVX512F__)
 
     typedef __m512 IntrVec_t;
     #define MPLEX_INTRINSICS_WIDTH_BYTES  64
     #define MPLEX_INTRINSICS_WIDTH_BITS  512
-    #define MIC_INTRINSICS
+    #define AVX512_INTRINSICS
     #define GATHER_INTRINSICS
     #define GATHER_IDX_LOAD(name, arr)  __m512i name = _mm512_load_epi32(arr);
 

--- a/Matriplex/MatriplexSym.h
+++ b/Matriplex/MatriplexSym.h
@@ -123,7 +123,7 @@ public:
       }
    }
 
-#if defined(MIC_INTRINSICS)
+#if defined(AVX512_INTRINSICS)
 
    template<typename U>
    void SlurpIn(const T *arr, __m512i& vi, const U&, const int N_proc = N)

--- a/Matriplex/test/GMtest.cxx
+++ b/Matriplex/test/GMtest.cxx
@@ -7,10 +7,8 @@
 /*
 # Generate .ah files (make sure DIM, DOM and pattern match):
   ./GMtest.pl
-# Compile host:
+# Compile:
   icc -std=gnu++11 -openmp -mavx -O3 -I.. -I../.. GMtest.cxx -o GMtest
-# Compile MIC:
-  icc -std=gnu++11 -openmp -mmic -O3 -I.. -I../.. GMtest.cxx -o GMtest-mic && scp GMtest-mic mic0:
 */
 
 typedef long long long64;
@@ -21,7 +19,7 @@ const int DIM =  3;
 const int DOM =  6;
 
 #ifdef MPLEX_INTRINSICS
-# if defined(__MIC__) || defined(__AVX512F__)
+# if defined(__AVX512F__)
 #   warning "MPLEX_INTRINSICS CMP_EPS = 2e-7 --> 3e-7"
 const float CMP_EPS = 3e-7;
 # elif defined(__AVX__)
@@ -32,7 +30,7 @@ const float CMP_EPS = 5e-7;
 const float CMP_EPS = 2e-7;
 # endif
 #else
-# if defined(__MIC__) || defined(__AVX512F__)
+# if defined(__AVX512F__)
 #   warning "NO MPLEX_INTRINSICS CMP_EPS = 4e-7"
 const float CMP_EPS = 4e-7;
 # else

--- a/Matrix.h
+++ b/Matrix.h
@@ -101,53 +101,50 @@ inline void sincos4(const float x, float& sin, float& cos)
    sin  = x - 0.16666667f*x*x2;
 }
 } // end namespace mkfit
+
 //==============================================================================
 
-// This ifdef needs to be changed to something like "use matriplex" and/or
-// "is icc" as we can only do vectorization with icc now.
+// Matriplex dimensions and typedefs
 
-#ifdef USE_MATRIPLEX
-
-  #ifdef __INTEL_COMPILER
-    #define ASSUME_ALIGNED(a, b) __assume_aligned(a, b)
-  #else
-    #define ASSUME_ALIGNED(a, b) a = static_cast<decltype(a)>(__builtin_assume_aligned(a, b))
-  #endif
-
-  #include "Matriplex/MatriplexSym.h"
-
-  namespace mkfit {
-
-  constexpr Matriplex::idx_t NN =  MPT_SIZE; // "Length" of MPlex.
-
-  constexpr Matriplex::idx_t LL =  6; // Dimension of large/long  MPlex entities
-  constexpr Matriplex::idx_t HH =  3; // Dimension of small/short MPlex entities
-
-  typedef Matriplex::Matriplex<float, LL, LL, NN>   MPlexLL;
-  typedef Matriplex::Matriplex<float, LL,  1, NN>   MPlexLV;
-  typedef Matriplex::MatriplexSym<float, LL,  NN>   MPlexLS;
-
-  typedef Matriplex::Matriplex<float, HH, HH, NN>   MPlexHH;
-  typedef Matriplex::Matriplex<float, HH,  1, NN>   MPlexHV;
-  typedef Matriplex::MatriplexSym<float, HH,  NN>   MPlexHS;
-
-  typedef Matriplex::Matriplex<float, 2,  2, NN>    MPlex22;
-  typedef Matriplex::Matriplex<float, 2,  1, NN>    MPlex2V;
-  typedef Matriplex::MatriplexSym<float,  2, NN>    MPlex2S;
-
-  typedef Matriplex::Matriplex<float, LL, HH, NN>   MPlexLH;
-  typedef Matriplex::Matriplex<float, HH, LL, NN>   MPlexHL;
-
-  typedef Matriplex::Matriplex<float, LL,  2, NN>   MPlexL2;
-
-  typedef Matriplex::Matriplex<float, 1, 1, NN>     MPlexQF;
-  typedef Matriplex::Matriplex<int,   1, 1, NN>     MPlexQI;
-  typedef Matriplex::Matriplex<unsigned int,   1, 1, NN>     MPlexQUI;
-
-  typedef Matriplex::Matriplex<bool,  1, 1, NN>     MPlexQB;
-
-  } // end namespace mkfit
+#ifdef __INTEL_COMPILER
+  #define ASSUME_ALIGNED(a, b) __assume_aligned(a, b)
+#else
+  #define ASSUME_ALIGNED(a, b) a = static_cast<decltype(a)>(__builtin_assume_aligned(a, b))
 #endif
+
+#include "Matriplex/MatriplexSym.h"
+
+namespace mkfit {
+
+constexpr Matriplex::idx_t NN =  MPT_SIZE; // "Length" of MPlex.
+
+constexpr Matriplex::idx_t LL =  6; // Dimension of large/long  MPlex entities
+constexpr Matriplex::idx_t HH =  3; // Dimension of small/short MPlex entities
+
+typedef Matriplex::Matriplex<float, LL, LL, NN>   MPlexLL;
+typedef Matriplex::Matriplex<float, LL,  1, NN>   MPlexLV;
+typedef Matriplex::MatriplexSym<float, LL,  NN>   MPlexLS;
+
+typedef Matriplex::Matriplex<float, HH, HH, NN>   MPlexHH;
+typedef Matriplex::Matriplex<float, HH,  1, NN>   MPlexHV;
+typedef Matriplex::MatriplexSym<float, HH,  NN>   MPlexHS;
+
+typedef Matriplex::Matriplex<float, 2,  2, NN>    MPlex22;
+typedef Matriplex::Matriplex<float, 2,  1, NN>    MPlex2V;
+typedef Matriplex::MatriplexSym<float,  2, NN>    MPlex2S;
+
+typedef Matriplex::Matriplex<float, LL, HH, NN>   MPlexLH;
+typedef Matriplex::Matriplex<float, HH, LL, NN>   MPlexHL;
+
+typedef Matriplex::Matriplex<float, LL,  2, NN>   MPlexL2;
+
+typedef Matriplex::Matriplex<float, 1, 1, NN>     MPlexQF;
+typedef Matriplex::Matriplex<int,   1, 1, NN>     MPlexQI;
+typedef Matriplex::Matriplex<unsigned int,   1, 1, NN>     MPlexQUI;
+
+typedef Matriplex::Matriplex<bool,  1, 1, NN>     MPlexQB;
+
+} // end namespace mkfit
 
 //==============================================================================
 

--- a/TrackerInfo.cc
+++ b/TrackerInfo.cc
@@ -117,11 +117,7 @@ namespace
 
 void TrackerInfo::ExecTrackerInfoCreatorPlugin(const std::string& base, TrackerInfo &ti, IterationsInfo &ii, bool verbose)
 {
-#ifdef __MIC__
-  std::string soname = base + "-mic.so";
-#else
   std::string soname = base + ".so";
-#endif
 
   struct stat st;
 

--- a/mkFit/config-parse/Makefile
+++ b/mkFit/config-parse/Makefile
@@ -6,7 +6,7 @@ libConfigDict.so: ConfigDict.cc
 	${CXX} -I.. -I../.. -I$(shell root-config --incdir) ${CPPFLAGS} -fPIC -shared -o $@ $^
 
 ConfigDict.cc: ../IterationConfig.h ../SteeringParams.h ConfigLinkDef.h
-	rootcling -f -D=USE_MATRIPLEX -I=.. -I=../.. $@ $^
+	rootcling -f -I=.. -I=../.. $@ $^
 
 clean:
 	rm -f libConfigDict.so ConfigDict.cc ConfigDict_rdict.pcm


### PR DESCRIPTION
Add SSE3 option to Makefile.config.

Set Matriplex width to 4 for SSE.


gcc-10, AMD Ryzen 7, cand build time, 10 events (after skipping 1st), best-out-of 2

```
   sse4   sse3   avx   avx2    avx-int  avx2-int
 4 2.30   2.34
 8 2.64          2.54  2.47    2.56     2.54
16 3.08                2.93
32                     3.71
```
