### PR TITLE
Add missing include in TTreeValidation.cc

### DIFF
--- a/TTreeValidation.cc
+++ b/TTreeValidation.cc
@@ -1,6 +1,7 @@
 #include "TTreeValidation.h"
 #include "Event.h"
 #include "Config.h"
+#include "mkFit/IterationConfig.h"
 
 #ifndef NO_ROOT
 


### PR DESCRIPTION
Fixes compilation error (with gcc) with `WITH_ROOT=1`
```
TTreeValidation.cc: In member function 'virtual void mkfit::TTreeValidation::fillConfigTree()':
TTreeValidation.cc:2379:38: error: no match for 'operator[]' (operand types are 'mkfit::IterationsInfo' and 'int')
 2379 |   nlayers_per_seed_ = Config::ItrInfo[0].m_params.nlayers_per_seed;
      |                                      ^
TTreeValidation.cc:2380:29: error: no match for 'operator[]' (operand types are 'mkfit::IterationsInfo' and 'int')
 2380 |   maxCand_ = Config::ItrInfo[0].m_params.maxCandsPerSeed;
      |                             ^
TTreeValidation.cc:2381:29: error: no match for 'operator[]' (operand types are 'mkfit::IterationsInfo' and 'int')
 2381 |   chi2Cut_ = Config::ItrInfo[0].m_params.chi2Cut;
      |                             ^
```
that were presumably caused by #314.