### PR TITLE
duplicate removal updated for iterations except pixelless and tobtec

### DIFF
--- a/Config.cc
+++ b/Config.cc
@@ -90,6 +90,12 @@ namespace Config
   float maxdR = 0.0025;
   float minFracHitsShared = 0.75;
 
+  float maxd1pt  = 0.9; //windows for hit 
+  float maxdphi = 0.37; //and/or dr
+  float maxdcth = 0.37;   //comparisons
+  float maxcth_ob = 1.99; //eta 1.44
+  float maxcth_fw = 6.05; //eta 2.5
+
   bool mtvLikeValidation = false;
   bool mtvRequireSeeds = false;
   int  cmsSelMinLayers = 12;

--- a/Config.h
+++ b/Config.h
@@ -329,6 +329,13 @@ namespace Config
   extern float minFracHitsShared;
   extern float maxdR;
 
+  //dup removal tighter version
+  extern float maxd1pt;
+  extern float maxdphi;
+  extern float maxdcth;
+  extern float maxcth_ob;
+  extern float maxcth_fw;
+
   // config on seed cleaning
   constexpr float track1GeVradius = 87.6; // = 1/(c*B)
   constexpr float c_etamax_brl = 0.9;

--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -344,36 +344,42 @@ namespace
     SetupIterationParams(ii[1].m_params, 1);
     ii[1].set_iteration_index_and_track_algorithm(1, (int) TrackBase::TrackAlgorithm::highPtTripletStep);
     ii[1].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.018, 0.018, 0.018, 0.05, 0.018, 0.05); 
+    ii[1].set_dupl_params(0.5, 0.03,0.05,0.08);
     fill_hit_selection_windows_params(ii[1]);
 
     ii[2].Clone(ii[0]); 
     SetupIterationParams(ii[2].m_params, 2);
     ii[2].set_iteration_index_and_track_algorithm(2, (int) TrackBase::TrackAlgorithm::lowPtQuadStep);
     ii[2].set_seed_cleaning_params(0.5, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
+    ii[2].set_dupl_params(0.5, 0.01,0.03,0.05);
     fill_hit_selection_windows_params(ii[2]);
      
     ii[3].Clone(ii[0]);
     SetupIterationParams(ii[3].m_params, 3);
     ii[3].set_iteration_index_and_track_algorithm(3, (int) TrackBase::TrackAlgorithm::lowPtTripletStep);
     ii[3].set_seed_cleaning_params(0.5, 0.0, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
+    ii[3].set_dupl_params(0.33, 0.018,0.05,0.018);
     fill_hit_selection_windows_params(ii[3]);
     
     ii[4].Clone(ii[0]);
     SetupIterationParams(ii[4].m_params, 4);
     ii[4].set_iteration_index_and_track_algorithm(4, (int) TrackBase::TrackAlgorithm::detachedQuadStep);
     ii[4].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
+    ii[4].set_dupl_params(0.25, 0.018,0.05,0.05);
     fill_hit_selection_windows_params(ii[4]);
     
     ii[5].Clone(ii[0]);
     SetupIterationParams(ii[5].m_params, 5);
     ii[5].set_iteration_index_and_track_algorithm(5, (int) TrackBase::TrackAlgorithm::detachedTripletStep);
     ii[5].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
+    ii[5].set_dupl_params(0.25, 0.05,0.05,0.05);
     fill_hit_selection_windows_params(ii[5]);
 
     ii[6].Clone(ii[0]);
     SetupIterationParams(ii[6].m_params, 6);
     ii[6].set_iteration_index_and_track_algorithm(6, (int) TrackBase::TrackAlgorithm::mixedTripletStep);
     ii[6].set_seed_cleaning_params(2.0, 0.05, 0.05, 0.135, 0.135, 0.05, 0.05, 0.135, 0.135);
+    ii[6].set_dupl_params(0.2, 0.05,0.05,0.05); 
     fill_hit_selection_windows_params(ii[6]);
 
     ii[7].Clone(ii[0]);
@@ -398,6 +404,7 @@ namespace
     SetupIterationParams(ii[9].m_params, 9);
     ii[9].set_iteration_index_and_track_algorithm(9, (int) TrackBase::TrackAlgorithm::pixelPairStep);
     ii[9].set_seed_cleaning_params(2.0, 0.135, 0.135, 0.135, 0.135, 0.135, 0.135, 0.135, 0.135);
+    ii[9].set_dupl_params(0.5, 0.03,0.05,0.08); //to update it
     fill_hit_selection_windows_params(ii[9]);
 
     if (verbose)

--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -344,7 +344,7 @@ namespace
     SetupIterationParams(ii[1].m_params, 1);
     ii[1].set_iteration_index_and_track_algorithm(1, (int) TrackBase::TrackAlgorithm::highPtTripletStep);
     ii[1].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.018, 0.018, 0.018, 0.05, 0.018, 0.05); 
-    ii[1].set_dupcleam_flag();
+    ii[1].set_dupclean_flag();
     ii[1].set_dupl_params(0.5, 0.03,0.05,0.08);
     fill_hit_selection_windows_params(ii[1]);
 
@@ -352,7 +352,7 @@ namespace
     SetupIterationParams(ii[2].m_params, 2);
     ii[2].set_iteration_index_and_track_algorithm(2, (int) TrackBase::TrackAlgorithm::lowPtQuadStep);
     ii[2].set_seed_cleaning_params(0.5, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
-    ii[1].set_dupcleam_flag();
+    ii[1].set_dupclean_flag();
     ii[2].set_dupl_params(0.5, 0.01,0.03,0.05);
     fill_hit_selection_windows_params(ii[2]);
      
@@ -360,7 +360,7 @@ namespace
     SetupIterationParams(ii[3].m_params, 3);
     ii[3].set_iteration_index_and_track_algorithm(3, (int) TrackBase::TrackAlgorithm::lowPtTripletStep);
     ii[3].set_seed_cleaning_params(0.5, 0.0, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
-    ii[3].set_dupcleam_flag();
+    ii[3].set_dupclean_flag();
     ii[3].set_dupl_params(0.33, 0.018,0.05,0.018);
     fill_hit_selection_windows_params(ii[3]);
     
@@ -368,7 +368,7 @@ namespace
     SetupIterationParams(ii[4].m_params, 4);
     ii[4].set_iteration_index_and_track_algorithm(4, (int) TrackBase::TrackAlgorithm::detachedQuadStep);
     ii[4].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
-    ii[4].set_dupcleam_flag();
+    ii[4].set_dupclean_flag();
     ii[4].set_dupl_params(0.25, 0.018,0.05,0.05);
     fill_hit_selection_windows_params(ii[4]);
     
@@ -376,7 +376,7 @@ namespace
     SetupIterationParams(ii[5].m_params, 5);
     ii[5].set_iteration_index_and_track_algorithm(5, (int) TrackBase::TrackAlgorithm::detachedTripletStep);
     ii[5].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
-    ii[5].set_dupcleam_flag();
+    ii[5].set_dupclean_flag();
     ii[5].set_dupl_params(0.25, 0.05,0.05,0.05);
     fill_hit_selection_windows_params(ii[5]);
 
@@ -384,7 +384,7 @@ namespace
     SetupIterationParams(ii[6].m_params, 6);
     ii[6].set_iteration_index_and_track_algorithm(6, (int) TrackBase::TrackAlgorithm::mixedTripletStep);
     ii[6].set_seed_cleaning_params(2.0, 0.05, 0.05, 0.135, 0.135, 0.05, 0.05, 0.135, 0.135);
-    ii[6].set_dupcleam_flag();
+    ii[6].set_dupclean_flag();
     ii[6].set_dupl_params(0.2, 0.05,0.05,0.05); 
     fill_hit_selection_windows_params(ii[6]);
 
@@ -410,7 +410,7 @@ namespace
     SetupIterationParams(ii[9].m_params, 9);
     ii[9].set_iteration_index_and_track_algorithm(9, (int) TrackBase::TrackAlgorithm::pixelPairStep);
     ii[9].set_seed_cleaning_params(2.0, 0.135, 0.135, 0.135, 0.135, 0.135, 0.135, 0.135, 0.135);
-    ii[9].set_dupcleam_flag();
+    ii[9].set_dupclean_flag();
     ii[9].set_dupl_params(0.5, 0.03,0.05,0.08); //to update it
     fill_hit_selection_windows_params(ii[9]);
 

--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -344,6 +344,7 @@ namespace
     SetupIterationParams(ii[1].m_params, 1);
     ii[1].set_iteration_index_and_track_algorithm(1, (int) TrackBase::TrackAlgorithm::highPtTripletStep);
     ii[1].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.018, 0.018, 0.018, 0.05, 0.018, 0.05); 
+    ii[1].set_dupcleam_flag();
     ii[1].set_dupl_params(0.5, 0.03,0.05,0.08);
     fill_hit_selection_windows_params(ii[1]);
 
@@ -351,6 +352,7 @@ namespace
     SetupIterationParams(ii[2].m_params, 2);
     ii[2].set_iteration_index_and_track_algorithm(2, (int) TrackBase::TrackAlgorithm::lowPtQuadStep);
     ii[2].set_seed_cleaning_params(0.5, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
+    ii[1].set_dupcleam_flag();
     ii[2].set_dupl_params(0.5, 0.01,0.03,0.05);
     fill_hit_selection_windows_params(ii[2]);
      
@@ -358,6 +360,7 @@ namespace
     SetupIterationParams(ii[3].m_params, 3);
     ii[3].set_iteration_index_and_track_algorithm(3, (int) TrackBase::TrackAlgorithm::lowPtTripletStep);
     ii[3].set_seed_cleaning_params(0.5, 0.0, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
+    ii[3].set_dupcleam_flag();
     ii[3].set_dupl_params(0.33, 0.018,0.05,0.018);
     fill_hit_selection_windows_params(ii[3]);
     
@@ -365,6 +368,7 @@ namespace
     SetupIterationParams(ii[4].m_params, 4);
     ii[4].set_iteration_index_and_track_algorithm(4, (int) TrackBase::TrackAlgorithm::detachedQuadStep);
     ii[4].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
+    ii[4].set_dupcleam_flag();
     ii[4].set_dupl_params(0.25, 0.018,0.05,0.05);
     fill_hit_selection_windows_params(ii[4]);
     
@@ -372,6 +376,7 @@ namespace
     SetupIterationParams(ii[5].m_params, 5);
     ii[5].set_iteration_index_and_track_algorithm(5, (int) TrackBase::TrackAlgorithm::detachedTripletStep);
     ii[5].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
+    ii[5].set_dupcleam_flag();
     ii[5].set_dupl_params(0.25, 0.05,0.05,0.05);
     fill_hit_selection_windows_params(ii[5]);
 
@@ -379,6 +384,7 @@ namespace
     SetupIterationParams(ii[6].m_params, 6);
     ii[6].set_iteration_index_and_track_algorithm(6, (int) TrackBase::TrackAlgorithm::mixedTripletStep);
     ii[6].set_seed_cleaning_params(2.0, 0.05, 0.05, 0.135, 0.135, 0.05, 0.05, 0.135, 0.135);
+    ii[6].set_dupcleam_flag();
     ii[6].set_dupl_params(0.2, 0.05,0.05,0.05); 
     fill_hit_selection_windows_params(ii[6]);
 
@@ -404,6 +410,7 @@ namespace
     SetupIterationParams(ii[9].m_params, 9);
     ii[9].set_iteration_index_and_track_algorithm(9, (int) TrackBase::TrackAlgorithm::pixelPairStep);
     ii[9].set_seed_cleaning_params(2.0, 0.135, 0.135, 0.135, 0.135, 0.135, 0.135, 0.135, 0.135);
+    ii[9].set_dupcleam_flag();
     ii[9].set_dupl_params(0.5, 0.03,0.05,0.08); //to update it
     fill_hit_selection_windows_params(ii[9]);
 

--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -338,6 +338,8 @@ namespace
     SetupSteeringParams_Iter0(ii[0]);
     SetupIterationParams(ii[0].m_params, 0);
     ii[0].m_partition_seeds = PartitionSeeds0;
+    ii[0].set_dupclean_flag();
+    ii[0].set_dupl_params(0.5, 0.002,0.004,0.008);
     fill_hit_selection_windows_params(ii[0]);
 
     ii[1].Clone(ii[0]); //added extra iterations with some preliminary setup
@@ -352,7 +354,7 @@ namespace
     SetupIterationParams(ii[2].m_params, 2);
     ii[2].set_iteration_index_and_track_algorithm(2, (int) TrackBase::TrackAlgorithm::lowPtQuadStep);
     ii[2].set_seed_cleaning_params(0.5, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
-    ii[1].set_dupclean_flag();
+    ii[2].set_dupclean_flag();
     ii[2].set_dupl_params(0.5, 0.01,0.03,0.05);
     fill_hit_selection_windows_params(ii[2]);
      

--- a/mkFit/IterationConfig.cc
+++ b/mkFit/IterationConfig.cc
@@ -55,7 +55,12 @@ ITCONF_DEFINE_TYPE_NON_INTRUSIVE(mkfit::IterationParams,
   /* float */   c_drmax_bl,
   /* float */   c_dzmax_bl,
   /* float */   c_drmax_el,
-  /* float */   c_dzmax_el
+  /* float */   c_dzmax_el,
+  /* float */   fracSharedHits,
+  /* float */   drth_central,
+  /* float */   drth_obarrel,
+  /* float */   drth_forward
+
 )
 
 ITCONF_DEFINE_TYPE_NON_INTRUSIVE(mkfit::IterationConfig,
@@ -64,6 +69,7 @@ ITCONF_DEFINE_TYPE_NON_INTRUSIVE(mkfit::IterationConfig,
   /* mkfit::IterationParams */   m_params,
   /* bool */                     m_requires_seed_hit_sorting,
   /* bool */                     m_require_quality_filter,
+  /* bool */                     m_require_dupclean_tight,
   // /* int */                   m_n_regions,
   // /* vector<int> */           m_region_order,
   // /* vector<mkfit::SteeringParams> */      m_steering_params,

--- a/mkFit/IterationConfig.h
+++ b/mkFit/IterationConfig.h
@@ -202,7 +202,7 @@ public:
      m_params.fracSharedHits=sharedFrac;
   }
 
-  void set_dupcleam_flag()
+  void set_dupclean_flag()
   {
     m_require_dupclean_tight=true;
   }

--- a/mkFit/IterationConfig.h
+++ b/mkFit/IterationConfig.h
@@ -117,6 +117,9 @@ public:
 
   int minHitsQF = 4;
   float fracSharedHits = 0.19;
+  float drth_central = 0.001; 
+  float drth_obarrel = 0.001;
+  float drth_forward = 0.001;
 
 };
 
@@ -197,6 +200,15 @@ public:
      m_params.minHitsQF=minHits;
      m_params.fracSharedHits=sharedFrac;
   }
+
+  void set_dupl_params(float sharedFrac, float drthCentral, float drthObarrel, float drthForward)
+  {
+      m_params.fracSharedHits=sharedFrac;
+      m_params.drth_central=drthCentral;
+      m_params.drth_obarrel=drthObarrel;
+      m_params.drth_forward=drthForward;
+  }  
+  
   
   void set_seed_cleaning_params(float pt_thr,
         float dzmax_bh, float drmax_bh,

--- a/mkFit/IterationConfig.h
+++ b/mkFit/IterationConfig.h
@@ -153,6 +153,7 @@ public:
 
   bool  m_requires_seed_hit_sorting = false;
   bool  m_require_quality_filter    = false;
+  bool  m_require_dupclean_tight    = false;
 
   // Iteration parameters (could be a ptr)
   IterationParams                     m_params;
@@ -199,6 +200,11 @@ public:
   {
      m_params.minHitsQF=minHits;
      m_params.fracSharedHits=sharedFrac;
+  }
+
+  void set_dupcleam_flag()
+  {
+    m_require_dupclean_tight=true;
   }
 
   void set_dupl_params(float sharedFrac, float drthCentral, float drthObarrel, float drthForward)

--- a/mkFit/MkStdSeqs.cc
+++ b/mkFit/MkStdSeqs.cc
@@ -585,16 +585,16 @@ void find_and_remove_duplicates(TrackVec &tracks, const IterationConfig &itconf)
   {
     find_duplicates_sharedhits(tracks, itconf.m_params.fracSharedHits);
   }
-  else //regular dupl cleaning
+  else if(itconf.m_require_dupclean_tight) 
   {
-    if(itconf.m_track_algorithm==4)
-    {
-      find_duplicates(tracks);
-      remove_duplicates(tracks);
-    }
-    else find_duplicates_sharedhits_pixelseed(tracks,itconf.m_params.fracSharedHits, itconf.m_params.drth_central, itconf.m_params.drth_obarrel, itconf.m_params.drth_forward);
-
+    find_duplicates_sharedhits_pixelseed(tracks, itconf.m_params.fracSharedHits, itconf.m_params.drth_central, itconf.m_params.drth_obarrel, itconf.m_params.drth_forward);
   }
+  else
+  {
+    find_duplicates(tracks);
+    remove_duplicates(tracks);
+  }
+
 }
 
 //=========================================================================

--- a/mkFit/MkStdSeqs.cc
+++ b/mkFit/MkStdSeqs.cc
@@ -509,18 +509,17 @@ void find_duplicates_sharedhits_pixelseed(TrackVec &tracks, const float fraction
        
        dctheta = std::abs(1./tan(track2.theta()) - ctheta1);
        
-       if (dctheta > 0.37)
+       if (dctheta > Config::maxdcth)
          continue;
 
        dphi = std::abs(squashPhiMinimal(phi1 - track2.momPhi()));
        
-       if (dphi > 0.37)
+       if (dphi > Config::maxdphi)
          continue;
        
-       //float maxdR = 0.001;//Config::maxdR; // maxdR = 0.0025
-       float maxdRSquared = drth_central*drth_central; //0.03*0.03;//maxdR * maxdR;
-       if (std::abs(ctheta1)>6.05f) maxdRSquared=drth_forward*drth_forward;//
-       else if (std::abs(ctheta1)>1.99f) maxdRSquared=drth_obarrel*drth_obarrel;//
+       float maxdRSquared = drth_central*drth_central;
+       if (std::abs(ctheta1)>Config::maxcth_fw) maxdRSquared=drth_forward*drth_forward;
+       else if (std::abs(ctheta1)>Config::maxcth_ob) maxdRSquared=drth_obarrel*drth_obarrel;
        dr2 = dphi * dphi + dctheta * dctheta;
        if (dr2 < maxdRSquared)
        {
@@ -532,7 +531,7 @@ void find_duplicates_sharedhits_pixelseed(TrackVec &tracks, const float fraction
          continue;
        }
 
-       if (std::abs(track2.invpT() - invpt1) > 0.9)
+       if (std::abs(track2.invpT() - invpt1) > Config::maxd1pt)
            continue;
 
        auto sharedCount=0; 

--- a/mkFit/MkStdSeqs.cc
+++ b/mkFit/MkStdSeqs.cc
@@ -537,6 +537,7 @@ void find_duplicates_sharedhits_pixelseed(TrackVec &tracks, const float fraction
 
        auto sharedCount=0; 
        auto sharedFirst=0;
+       const auto minFoundHits = std::min(trk.nFoundHits(), track2.nFoundHits());
 
        for (int i = 0; i < trk.nTotalHits(); ++i)
        {
@@ -551,15 +552,15 @@ void find_duplicates_sharedhits_pixelseed(TrackVec &tracks, const float fraction
 
            //this is to count once shared matched hits (may be done more properly...)
            if(a==c && b==d) sharedCount+=1;
-           if(a==c && b==d && j==0 && i==0) sharedFirst+=1;
+           if(j==0 && i==0 && a==c && b==d) sharedFirst+=1;
 
-           if ((sharedCount - sharedFirst) >= ((std::min(trk.nFoundHits(), track2.nFoundHits()) - sharedFirst) * fraction)) continue;
+           if ((sharedCount - sharedFirst) >= ((minFoundHits - sharedFirst) * fraction)) continue;
          }
-         if ((sharedCount - sharedFirst) >= ((std::min(trk.nFoundHits(), track2.nFoundHits()) - sharedFirst) * fraction)) continue;
+         if ((sharedCount - sharedFirst) >= ((minFoundHits - sharedFirst) * fraction)) continue;
        }
 
        //selection here - 11percent fraction of shared hits to label a duplicate
-       if ((sharedCount - sharedFirst) >= ((std::min(trk.nFoundHits(), track2.nFoundHits()) - sharedFirst) * fraction))
+       if ((sharedCount - sharedFirst) >= ((minFoundHits - sharedFirst) * fraction))
        {
          if (trk.score() > track2.score())
            track2.setDuplicateValue(true);

--- a/mkFit/MkStdSeqs.h
+++ b/mkFit/MkStdSeqs.h
@@ -31,6 +31,7 @@ namespace StdSeq
       
     void quality_filter(TrackVec &tracks, const int nMinHits);
     void find_duplicates_sharedhits(TrackVec &tracks, const float fraction);
+    void find_duplicates_sharedhits_pixelseed(TrackVec &tracks, const float fraction, const float drth_central, const float drth_obarrel, const float drth_forward);
 
     template<class TRACK>
     bool qfilter_n_hits(const TRACK &t, int nMinHits)


### PR DESCRIPTION
The duplicate removal is updated for iterations lowPtQuad, highPtTriplet, lowPtTriplet, detachedQuad, detachedTriplet, mixedTriplet (pixelPair to be reviewed again). the efficiencies are still better or comparable to CMSSW with lower duplicate rates and slightly lower fake rates. 
the cleaning is based on dR (dphi, dcotan(theta)) and the fraction of hits shared by tracks. the comparisons are limited in dphi, dcotan(theta) d1/pT.

the PR code itself may be improved

**Comparison plots by iteration**

high pT triplet

[eff before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter22/?match=eff*fit)  -------------  [eff after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter22/?match=eff*fit)
[dup before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter22/?match=dr*fit)   -------------   [dup after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter22/?match=dr*fit)
[fake before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter22/?match=fr*fit)    -------------   [fake after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter22/?match=fr*fit)

low pT quad

[eff before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter23/?match=eff*fit)  -------------  [eff after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter23/?match=eff*fit)
[dup before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter23/?match=dr*fit)   -------------   [dup after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter23/?match=dr*fit)
[fake before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter23/?match=fr*fit)    -------------   [fake after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter23/?match=fr*fit)

low pT triplet

[eff before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter5/?match=eff*fit)  -------------  [eff after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter5/?match=eff*fit)
[dup before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter5/?match=dr*fit)   -------------   [dup after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter5/?match=dr*fit)
[fake before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter5/?match=fr*fit)    -------------   [fake after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter5/?match=fr*fit)

detached quad

[eff before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter24/?match=eff*fit)  -------------  [eff after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter24/?match=eff*fit)
[dup before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter24/?match=dr*fit)   -------------   [dup after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter24/?match=dr*fit)
[fake before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter24/?match=fr*fit)    -------------   [fake after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter24/?match=fr*fit)

detached triplet

[eff before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter7/?match=eff*fit)  -------------  [eff after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter7/?match=eff*fit)
[dup before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter7/?match=dr*fit)   -------------   [dup after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter7/?match=dr*fit)
[fake before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter7/?match=fr*fit)    -------------   [fake after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter7/?match=fr*fit)

mixed triplet

[eff before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter8/?match=eff*fit)  -------------  [eff after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter8/?match=eff*fit)
[dup before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter8/?match=dr*fit)   -------------   [dup after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter8/?match=dr*fit)
[fake before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_SEED_iter8/?match=fr*fit)    -------------   [fake after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_SEED_iter8/?match=fr*fit)


**Counts**

[high pT triplet before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_iter22/totals_validation_SKL-SP_CMSSW_TTbar_PU50_CE_SIMVAL_iter22.txt) ---- [high pT triplet after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_iter22/totals_validation_SKL-SP_CMSSW_TTbar_PU50_CE_SIMVAL_iter22.txt)
[low pt quad  before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_iter23/totals_validation_SKL-SP_CMSSW_TTbar_PU50_CE_SIMVAL_iter23.txt)  ----  [low pt quad after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_iter23/totals_validation_SKL-SP_CMSSW_TTbar_PU50_CE_SIMVAL_iter23.txt)
[detached quad before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_iter24/totals_validation_SKL-SP_CMSSW_TTbar_PU50_CE_SIMVAL_iter24.txt) -----  [detached quad  after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_iter24/totals_validation_SKL-SP_CMSSW_TTbar_PU50_CE_SIMVAL_iter24.txt)
[low pT triplet before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_iter5/totals_validation_SKL-SP_CMSSW_TTbar_PU50_CE_SIMVAL_iter5.txt) ---- [low pT triplet after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_iter5/totals_validation_SKL-SP_CMSSW_TTbar_PU50_CE_SIMVAL_iter5.txt)
[detached triplet before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_iter7/totals_validation_SKL-SP_CMSSW_TTbar_PU50_CE_SIMVAL_iter7.txt) ----  [detached triplet after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_iter7/totals_validation_SKL-SP_CMSSW_TTbar_PU50_CE_SIMVAL_iter7.txt)
[mixed triplet before](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_baseline/SIMVAL_MTV_iter8/totals_validation_SKL-SP_CMSSW_TTbar_PU50_CE_SIMVAL_iter8.txt) ----  [mixed triplet after](http://uaf-10.t2.ucsd.edu/~lgiannini/PR_dupcleaning/benchmarks_newdupremoval/SIMVAL_MTV_iter8/totals_validation_SKL-SP_CMSSW_TTbar_PU50_CE_SIMVAL_iter8.txt)







