### PR TITLE
tracking ntuple to bin file with seed based on curvilinear covariance

### DIFF
--- a/tkNtuple/WriteMemoryFile.cc
+++ b/tkNtuple/WriteMemoryFile.cc
@@ -326,6 +326,7 @@ int main(int argc, char *argv[])
   std::vector<float>*   see_stateCcov44 = 0;
   std::vector<float>*   see_stateCcov45 = 0;
   std::vector<float>*   see_stateCcov55 = 0;
+  std::vector<std::vector<float> >* see_stateCurvCov = 0;
   std::vector<int>*     see_q = 0;
   std::vector<unsigned int>*     see_algo = 0;
   t->SetBranchAddress("see_stateTrajGlbX",&see_stateTrajGlbX);
@@ -336,27 +337,33 @@ int main(int argc, char *argv[])
   t->SetBranchAddress("see_stateTrajGlbPz",&see_stateTrajGlbPz);
   t->SetBranchAddress("see_eta",&see_eta);
   t->SetBranchAddress("see_pt",&see_pt);
-  t->SetBranchAddress("see_stateCcov00",&see_stateCcov00);
-  t->SetBranchAddress("see_stateCcov01",&see_stateCcov01);
-  t->SetBranchAddress("see_stateCcov02",&see_stateCcov02);
-  t->SetBranchAddress("see_stateCcov03",&see_stateCcov03);
-  t->SetBranchAddress("see_stateCcov04",&see_stateCcov04);
-  t->SetBranchAddress("see_stateCcov05",&see_stateCcov05);
-  t->SetBranchAddress("see_stateCcov11",&see_stateCcov11);
-  t->SetBranchAddress("see_stateCcov12",&see_stateCcov12);
-  t->SetBranchAddress("see_stateCcov13",&see_stateCcov13);
-  t->SetBranchAddress("see_stateCcov14",&see_stateCcov14);
-  t->SetBranchAddress("see_stateCcov15",&see_stateCcov15);
-  t->SetBranchAddress("see_stateCcov22",&see_stateCcov22);
-  t->SetBranchAddress("see_stateCcov23",&see_stateCcov23);
-  t->SetBranchAddress("see_stateCcov24",&see_stateCcov24);
-  t->SetBranchAddress("see_stateCcov25",&see_stateCcov25);
-  t->SetBranchAddress("see_stateCcov33",&see_stateCcov33);
-  t->SetBranchAddress("see_stateCcov34",&see_stateCcov34);
-  t->SetBranchAddress("see_stateCcov35",&see_stateCcov35);
-  t->SetBranchAddress("see_stateCcov44",&see_stateCcov44);
-  t->SetBranchAddress("see_stateCcov45",&see_stateCcov45);
-  t->SetBranchAddress("see_stateCcov55",&see_stateCcov55);
+
+  bool hasCartCov = t->GetBranch("see_stateCcov00") != nullptr;
+  if (hasCartCov) {
+    t->SetBranchAddress("see_stateCcov00",&see_stateCcov00);
+    t->SetBranchAddress("see_stateCcov01",&see_stateCcov01);
+    t->SetBranchAddress("see_stateCcov02",&see_stateCcov02);
+    t->SetBranchAddress("see_stateCcov03",&see_stateCcov03);
+    t->SetBranchAddress("see_stateCcov04",&see_stateCcov04);
+    t->SetBranchAddress("see_stateCcov05",&see_stateCcov05);
+    t->SetBranchAddress("see_stateCcov11",&see_stateCcov11);
+    t->SetBranchAddress("see_stateCcov12",&see_stateCcov12);
+    t->SetBranchAddress("see_stateCcov13",&see_stateCcov13);
+    t->SetBranchAddress("see_stateCcov14",&see_stateCcov14);
+    t->SetBranchAddress("see_stateCcov15",&see_stateCcov15);
+    t->SetBranchAddress("see_stateCcov22",&see_stateCcov22);
+    t->SetBranchAddress("see_stateCcov23",&see_stateCcov23);
+    t->SetBranchAddress("see_stateCcov24",&see_stateCcov24);
+    t->SetBranchAddress("see_stateCcov25",&see_stateCcov25);
+    t->SetBranchAddress("see_stateCcov33",&see_stateCcov33);
+    t->SetBranchAddress("see_stateCcov34",&see_stateCcov34);
+    t->SetBranchAddress("see_stateCcov35",&see_stateCcov35);
+    t->SetBranchAddress("see_stateCcov44",&see_stateCcov44);
+    t->SetBranchAddress("see_stateCcov45",&see_stateCcov45);
+    t->SetBranchAddress("see_stateCcov55",&see_stateCcov55);
+  } else {
+    t->SetBranchAddress("see_stateCurvCov",&see_stateCurvCov);
+  }
   t->SetBranchAddress("see_q",&see_q);
   t->SetBranchAddress("see_algo",&see_algo);
 
@@ -758,29 +765,41 @@ int main(int argc, char *argv[])
       SVector3 pos = SVector3(see_stateTrajGlbX->at(is),see_stateTrajGlbY->at(is),see_stateTrajGlbZ->at(is));
       SVector3 mom = SVector3(see_stateTrajGlbPx->at(is),see_stateTrajGlbPy->at(is),see_stateTrajGlbPz->at(is));
       SMatrixSym66 err;
-      err.At(0,0) = see_stateCcov00->at(is);
-      err.At(0,1) = see_stateCcov01->at(is);
-      err.At(0,2) = see_stateCcov02->at(is);
-      err.At(0,3) = see_stateCcov03->at(is);
-      err.At(0,4) = see_stateCcov04->at(is);
-      err.At(0,5) = see_stateCcov05->at(is);
-      err.At(1,1) = see_stateCcov11->at(is);
-      err.At(1,2) = see_stateCcov12->at(is);
-      err.At(1,3) = see_stateCcov13->at(is);
-      err.At(1,4) = see_stateCcov14->at(is);
-      err.At(1,5) = see_stateCcov15->at(is);
-      err.At(2,2) = see_stateCcov22->at(is);
-      err.At(2,3) = see_stateCcov23->at(is);
-      err.At(2,4) = see_stateCcov24->at(is);
-      err.At(2,5) = see_stateCcov25->at(is);
-      err.At(3,3) = see_stateCcov33->at(is);
-      err.At(3,4) = see_stateCcov34->at(is);
-      err.At(3,5) = see_stateCcov35->at(is);
-      err.At(4,4) = see_stateCcov44->at(is);
-      err.At(4,5) = see_stateCcov45->at(is);
-      err.At(5,5) = see_stateCcov55->at(is);
+      if (hasCartCov) {
+        err.At(0,0) = see_stateCcov00->at(is);
+        err.At(0,1) = see_stateCcov01->at(is);
+        err.At(0,2) = see_stateCcov02->at(is);
+        err.At(0,3) = see_stateCcov03->at(is);
+        err.At(0,4) = see_stateCcov04->at(is);
+        err.At(0,5) = see_stateCcov05->at(is);
+        err.At(1,1) = see_stateCcov11->at(is);
+        err.At(1,2) = see_stateCcov12->at(is);
+        err.At(1,3) = see_stateCcov13->at(is);
+        err.At(1,4) = see_stateCcov14->at(is);
+        err.At(1,5) = see_stateCcov15->at(is);
+        err.At(2,2) = see_stateCcov22->at(is);
+        err.At(2,3) = see_stateCcov23->at(is);
+        err.At(2,4) = see_stateCcov24->at(is);
+        err.At(2,5) = see_stateCcov25->at(is);
+        err.At(3,3) = see_stateCcov33->at(is);
+        err.At(3,4) = see_stateCcov34->at(is);
+        err.At(3,5) = see_stateCcov35->at(is);
+        err.At(4,4) = see_stateCcov44->at(is);
+        err.At(4,5) = see_stateCcov45->at(is);
+        err.At(5,5) = see_stateCcov55->at(is);
+      } else {
+        auto const& vCov = see_stateCurvCov->at(is);
+        assert(vCov.size() == 15);
+        auto vCovP = vCov.begin();
+        for (int i = 0; i < 5; ++i)
+          for (int j = 0; j <= i; ++j)
+            err.At(i,j) = *(vCovP++);
+      }
       TrackState state(see_q->at(is), pos, mom, err);
-      state.convertFromCartesianToCCS();
+      if (hasCartCov)
+        state.convertFromCartesianToCCS();
+      else
+        state.convertFromGlbCurvilinearToCCS();
       Track track(state, 0, seedSimIdx[is], 0, nullptr);
       track.setAlgorithm(isAlgo);
       auto const& shTypes = see_hitType->at(is);

--- a/val_scripts/validation-cmssw-benchmarks-multiiter.sh
+++ b/val_scripts/validation-cmssw-benchmarks-multiiter.sh
@@ -26,6 +26,14 @@ case ${inputBin} in
         subdir=/initialStep/default/11024.0_TTbar_13/AVE_50_BX01_25ns/RAW4NT  
         file=/memoryFile.fv5.clean.writeAll.CCC1620.recT.allSeeds.masks.201023-64302e5.bin
         ;;
+"112X_10mu_MULTI")
+        echo "Inputs from 2021 10mu sample with multiple iterations and hit binary mask"
+        dir=/data2/slava77/samples
+        subdir=2021/10muPt0p2to1000HS
+        file=memoryFile.fv5.default.210623-b62fc88.bin
+        nevents=20000
+        sample=10mu
+        ;;
 *)
         echo "INPUT BIN IS UNKNOWN"
         exit 12

--- a/xeon_scripts/common-variables.sh
+++ b/xeon_scripts/common-variables.sh
@@ -6,7 +6,7 @@ useARCH=${2:-0} # which computer cluster to run on. 0=phi3, 1=lnx, 2= phi3+lnx, 
 lnxuser=${3:-${USER}} #username for lnx computers
 
 # samples
-export sample=CMSSW_TTbar_PU50
+export sample=${sample:-"CMSSW_TTbar_PU50"}
 
 # Validation architecture
 export val_arch=SKL-SP


### PR DESCRIPTION
- updated WriteMemoryFile.cc to read from tracking ntuple using curvilinear covariance
- added `112X_10mu_MULTI` for inputBin sample in `val_scripts/validation-cmssw-benchmarks-multiiter.sh`

I'm puzzled, however:
- multiiter iter4 SIMVAL based on memoryFile.fv5.default.210607-00e28c8.bin, which is made using the Cartesian covariance http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/val/phi3/devel-pr324-covNt/benchmarks-10mu-ecddfe8_cart/SIMVAL_MTV_iter4/SKL-SP_10mu_eff_pt_build_pt0p0_SIMVAL_iter4.png
    - the track parameters do not agree here so well http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/val/phi3/devel-pr324-covNt/benchmarks-10mu-ecddfe8_cart/SIMVAL_MTV_iter4/diffs/SKL-SP_10mu_allmatch_deta_build_pt2p0_SIMVAL_iter4.png
- the same based on a new file http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/val/phi3/devel-pr324-covNt/benchmarks-10mu-ecddfe8/SIMVAL_MTV_iter4/SKL-SP_10mu_eff_pt_build_pt0p0_SIMVAL_iter4.png
    - the track parameters are more consistent now http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/val/phi3/devel-pr324-covNt/benchmarks-10mu-ecddfe8/SIMVAL_MTV_iter4/diffs/SKL-SP_10mu_allmatch_deta_build_pt2p0_SIMVAL_iter4.png

the puzzling part is that the efficiency does not agree with plots in https://github.com/trackreco/mkFit/pull/324#issue-676323448
Is the standalone validation fixing up the tracks in some way (and should we have enabled that way in CMSSW) ?

