### PR TITLE
Fix charge flip for STD

### DIFF
--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -857,7 +857,8 @@ void MkFinder::FindCandidates(const LayerOfHits                   &layer_of_hits
 
     if (oneCandPassCut)
     {
-      (*fnd_foos.m_update_param_foo)(Err[iP], Par[iP], Chg, msErr, msPar,
+      MPlexQI tmpChg = Chg;
+      (*fnd_foos.m_update_param_foo)(Err[iP], Par[iP], tmpChg, msErr, msPar,
                                      Err[iC], Par[iC], N_proc, Config::finding_intra_layer_pflags);
 
       dprint("update parameters" << std::endl
@@ -883,6 +884,7 @@ void MkFinder::FindCandidates(const LayerOfHits                   &layer_of_hits
 
             TrackCand newcand;
             copy_out(newcand, itrack, iC);
+            newcand.setCharge(tmpChg(itrack, 0, 0));
 	    newcand.addHitIdx(hit_idx, layer_of_hits.layer_id(), chi2);
 	    newcand.setScore(getScoreCand(newcand, true));
             newcand.setOriginIndex(CandIdx(itrack, 0, 0));


### PR DESCRIPTION
This PR addresses [Issue #301](https://github.com/trackreco/mkFit/issues/301) and fixes the implementation of the charge flip for Standard track building. STD and CE now give very similar results again.

The issue was that by overwriting `Chg`, then if the charge got flipped for a single candidate, it would be flipped for all later candidates from that seed. So for example, if the are two potential hits on layer X for seed i, if hit 0 causes a charge flip, then the flipped charge would be passed to the Kalman Update for hit 1. 

Baseline plots: https://areinsvo.web.cern.ch/areinsvo/MkFit/PandorasBox/baselineChgFlipStd
Results after this fix: https://areinsvo.web.cern.ch/areinsvo/MkFit/PandorasBox/fixChgFlipStd/
