### PR TITLE
FPE hunt side fixes

### DIFF
--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -355,7 +355,7 @@ namespace
     ii[3].Clone(ii[0]);
     SetupIterationParams(ii[3].m_params, 3);
     ii[3].set_iteration_index_and_track_algorithm(3, (int) TrackBase::TrackAlgorithm::lowPtTripletStep);
-    ii[3].set_seed_cleaning_params(0.5, 0.0, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
+    ii[3].set_seed_cleaning_params(0.5, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
     fill_hit_selection_windows_params(ii[3]);
     
     ii[4].Clone(ii[0]);

--- a/mkFit/KalmanUtilsMPlex.cc
+++ b/mkFit/KalmanUtilsMPlex.cc
@@ -498,8 +498,8 @@ void kalmanPropagateAndUpdate(const MPlexLS &psErr,  const MPlexLV& psPar, MPlex
   {
     if (outPar.At(n,3,0) < 0)
     {
-      Chg.At(n, 0, 0) = -1.0*Chg.ConstAt(n, 0, 0);
-      outPar.At(n,3,0) = std::abs(outPar.At(n,3,0));
+      Chg.At(n, 0, 0)  = -Chg.At(n, 0, 0);
+      outPar.At(n,3,0) = -outPar.At(n,3,0);
     }
   }
 }
@@ -724,8 +724,8 @@ void kalmanPropagateAndUpdateEndcap(const MPlexLS &psErr,  const MPlexLV& psPar,
   {
     if (outPar.At(n,3,0) < 0)
     {
-      Chg.At(n, 0, 0) = -1.0*Chg.ConstAt(n, 0, 0);
-      outPar.At(n,3,0) = std::abs(outPar.At(n,3,0));
+      Chg.At(n, 0, 0)  = -Chg.At(n, 0, 0);
+      outPar.At(n,3,0) = -outPar.At(n,3,0);
     }
   }
 }

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -1268,10 +1268,11 @@ void MkFinder::BkFitFitTracksBH(const EventOfHits   & eventofhits,
 
       if (CurHit[i] >= 0 && HoTArr[ i ][ CurHit[i] ].layer == layer)
       {
-        // Skip the overlap hit -- if it exists. Overlap hit gets placed *after* the
-        // original hit in TrackCand::exportTrack() -- which is *before* in the reverse
-        // iteration that we are doing here.
-        if (CurHit[i] > 0 && HoTArr[ i ][ CurHit[i] - 1 ].layer == layer) --CurHit[i];
+        // Skip the overlap hits -- if they exist.
+        // 1. Overlap hit gets placed *after* the original hit in TrackCand::exportTrack()
+        // which is *before* in the reverse iteration that we are doing here.
+        // 2. Seed-hit merging can result in more than two hits per layer.
+        while (CurHit[i] > 0 && HoTArr[ i ][ CurHit[i] - 1 ].layer == layer) --CurHit[i];
 
         const Hit &hit = L.GetHit( HoTArr[ i ][ CurHit[i] ].index );
         msErr.CopyIn(i, hit.errArray());

--- a/mkFit/MkStdSeqs.cc
+++ b/mkFit/MkStdSeqs.cc
@@ -282,8 +282,10 @@ int clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg)
             bool unique = true;
             for (int i = 0; i < tk.nTotalHits(); ++i)
             {
-              if ((hitidx == tk.getHitIdx(i)) && (hitlyr == tk.getHitLyr(i)))
+              if ((hitidx == tk.getHitIdx(i)) && (hitlyr == tk.getHitLyr(i))) {
                 unique = false;
+                break;
+              }
             }
             if (unique) {
               tk.addHitIdx(tk2.getHitIdx(j), tk2.getHitLyr(j), fakeChi2);
@@ -297,7 +299,7 @@ int clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg)
 
     if (writetrack[ts])
     {
-      if (n_ovlp_hits_added > 0 && ! itrcfg.m_requires_seed_hit_sorting)
+      if (n_ovlp_hits_added > 0)
         seeds[ts].sortHitsByLayer();
       cleanSeedTracks.emplace_back(seeds[ts]);
     }

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -548,6 +548,7 @@ int main(int argc, const char *argv[])
         "  --build-std              run standard combinatorial building test (def: %s)\n"
         "  --build-ce               run clone engine combinatorial building test (def: %s)\n"
         "  --build-mimi             run clone engine on multiple-iteration test (def: %s)\n"
+        "  --num-iters-cmssw <int>  number of mimi iterations to run (def: set to 3 when --build-mimi is in effect, 0 otherwise)\n"
 	"\n"
 	" **Seeding options\n"
         "  --seed-input     <str>   which seed collecion used for building (def: %s)\n"
@@ -777,11 +778,6 @@ int main(int argc, const char *argv[])
       next_arg_or_die(mArgs, i);
       Config::nEvents = atoi(i->c_str());
     }
-    else if (*i == "--num-iters-cmssw")
-    {
-       next_arg_or_die(mArgs, i);
-       Config::nItersCMSSW = atoi(i->c_str());
-    }
     else if (*i == "--start-event")
     {
       next_arg_or_die(mArgs, i);
@@ -858,6 +854,11 @@ int main(int argc, const char *argv[])
     {
       g_run_build_all = false; g_run_build_cmssw = false; g_run_build_bh = false; g_run_build_std = false; g_run_build_ce = false; g_run_build_mimi = true;
       if (Config::nItersCMSSW == 0) Config::nItersCMSSW = 3;
+    }
+    else if (*i == "--num-iters-cmssw")
+    {
+       next_arg_or_die(mArgs, i);
+       Config::nItersCMSSW = atoi(i->c_str());
     }
     else if(*i == "--seed-input")
     {


### PR DESCRIPTION
1. Fix IterationParams::c_dzmax_bh = 0 for iteration_index 3 / track_algo 5
2. Use - to do charge sign flip, do not multiply with -1.
3. When merging seed hits, always sort ... the iteration-specific sorting happens before, not after seed cleaning.
4. Handle more than 2 overlap hits per layer in bk-fit.
5. Document --num-iters-cmssw in --help text.

Points 3 and 4 could change results a bit as they affect backward-fit's propagation into seeding region ... can somebody please run relevant validations?