### PR TITLE
fix curv->CCS (3,0)

### DIFF
--- a/Track.cc
+++ b/Track.cc
@@ -138,7 +138,7 @@ SMatrix66 TrackState::jacobianCurvilinearToCCS(float px,float py,float pz, short
   jac(1,3) = cosPhi;
   jac(1,4) = -sinLam * sinPhi;
   jac(2,4) = cosLam;
-  jac(3,0) = charge * cosLam; //assumes |charge|==1 ; else 1.f/charge here
+  jac(3,0) = charge / cosLam; //assumes |charge|==1 ; else 1.f/charge here
   jac(3,1) = pz * invpt2;
   jac(4,2) = 1.f;
   jac(5,1) = -1.f;


### PR DESCRIPTION
while cross-checking the results of #324 I found a typo; this PR fixes the curvilinear to CCS Jacobian element that couples q/p with 1/pt.
The impact of the mistake was a decrease in uncertainty of 1/pt by sinTheta^2 (cosLambda^2) in the input seed

http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/10muHS_mk48b9f5b_sw5766e9f_vs_25bd4b9_v_mka3eddef-sw25bd4b9/

for built track initialStep:
<img width="250" alt="image" src="https://user-images.githubusercontent.com/4676718/124369342-bee97580-dc1f-11eb-8a76-6b28317e57d5.png"><img width="250" alt="image" src="https://user-images.githubusercontent.com/4676718/124369345-d7599000-dc1f-11eb-8ce8-5293d2d4ff5d.png"><img width="250" alt="image" src="https://user-images.githubusercontent.com/4676718/124369350-e0e2f800-dc1f-11eb-9f67-7efcb210d26d.png">

orange is new/fixed
- the reconstructed track hit count is now roughly recovered
- the efficiency vs eta is now more evenly different from CMSSW
- the average efficiency vs pt did not change much