### PR TITLE
adjust dupl. cleaning for pixel pair iteration

### DIFF
--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -413,7 +413,7 @@ namespace
     ii[9].set_iteration_index_and_track_algorithm(9, (int) TrackBase::TrackAlgorithm::pixelPairStep);
     ii[9].set_seed_cleaning_params(2.0, 0.135, 0.135, 0.135, 0.135, 0.135, 0.135, 0.135, 0.135);
     ii[9].set_dupclean_flag();
-    ii[9].set_dupl_params(0.5, 0.03,0.05,0.08); //to update it
+    ii[9].set_dupl_params(0.5, 0.03,0.05,0.05);
     fill_hit_selection_windows_params(ii[9]);
 
     if (verbose)


### PR DESCRIPTION
Checked duplicate cleaning params for pixel pair. There is almost no difference with respect to the guessed ones, but at least a check was made.

plots and totals can be found here

http://uaf-10.t2.ucsd.edu/~lgiannini/test_param_pixelPair/