### PR TITLE
PR #327 (solving existing conflicts) + dead modules option

### DIFF
--- a/Config.cc
+++ b/Config.cc
@@ -96,6 +96,8 @@ namespace Config
   float maxcth_ob = 1.99; //eta 1.44
   float maxcth_fw = 6.05; //eta 2.5
 
+  bool  useDeadModules = false;
+
   bool mtvLikeValidation = false;
   bool mtvRequireSeeds = false;
   int  cmsSelMinLayers = 12;

--- a/Config.cc
+++ b/Config.cc
@@ -84,17 +84,17 @@ namespace Config
 
   bool  removeDuplicates = false;
   bool  useHitsForDuplicates = true;
-  float maxdPt  = 0.5;
-  float maxdPhi = 0.25;
-  float maxdEta = 0.05;
-  float maxdR = 0.0025;
-  float minFracHitsShared = 0.75;
+  const float maxdPt  = 0.5;
+  const float maxdPhi = 0.25;
+  const float maxdEta = 0.05;
+  const float maxdR = 0.0025;
+  const float minFracHitsShared = 0.75;
 
-  float maxd1pt  = 0.9; //windows for hit 
-  float maxdphi = 0.37; //and/or dr
-  float maxdcth = 0.37;   //comparisons
-  float maxcth_ob = 1.99; //eta 1.44
-  float maxcth_fw = 6.05; //eta 2.5
+  const float maxd1pt  = 0.9; //windows for hit
+  const float maxdphi = 0.37; //and/or dr
+  const float maxdcth = 0.37;   //comparisons
+  const float maxcth_ob = 1.99; //eta 1.44
+  const float maxcth_fw = 6.05; //eta 2.5
 
   bool  useDeadModules = false;
 

--- a/Config.h
+++ b/Config.h
@@ -323,18 +323,18 @@ namespace Config
   // config on duplicate removal
   extern bool useHitsForDuplicates;
   extern bool removeDuplicates;
-  extern float maxdPhi;
-  extern float maxdPt;
-  extern float maxdEta;
-  extern float minFracHitsShared;
-  extern float maxdR;
+  extern const float maxdPhi;
+  extern const float maxdPt;
+  extern const float maxdEta;
+  extern const float minFracHitsShared;
+  extern const float maxdR;
 
-  //dup removal tighter version
-  extern float maxd1pt;
-  extern float maxdphi;
-  extern float maxdcth;
-  extern float maxcth_ob;
-  extern float maxcth_fw;
+  // duplicate removal: tighter version
+  extern const float maxd1pt;
+  extern const float maxdphi;
+  extern const float maxdcth;
+  extern const float maxcth_ob;
+  extern const float maxcth_fw;
 
   // config on dead modules
   extern bool useDeadModules;

--- a/Config.h
+++ b/Config.h
@@ -336,6 +336,9 @@ namespace Config
   extern float maxcth_ob;
   extern float maxcth_fw;
 
+  // config on dead modules
+  extern bool useDeadModules;
+
   // config on seed cleaning
   constexpr float track1GeVradius = 87.6; // = 1/(c*B)
   constexpr float c_etamax_brl = 0.9;

--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -355,7 +355,7 @@ namespace
     ii[3].Clone(ii[0]);
     SetupIterationParams(ii[3].m_params, 3);
     ii[3].set_iteration_index_and_track_algorithm(3, (int) TrackBase::TrackAlgorithm::lowPtTripletStep);
-    ii[3].set_seed_cleaning_params(0.5, 0.0, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
+    ii[3].set_seed_cleaning_params(0.5, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
     fill_hit_selection_windows_params(ii[3]);
     
     ii[4].Clone(ii[0]);

--- a/mkFit/KalmanUtilsMPlex.cc
+++ b/mkFit/KalmanUtilsMPlex.cc
@@ -498,8 +498,8 @@ void kalmanPropagateAndUpdate(const MPlexLS &psErr,  const MPlexLV& psPar, MPlex
   {
     if (outPar.At(n,3,0) < 0)
     {
-      Chg.At(n, 0, 0) = -1.0*Chg.ConstAt(n, 0, 0);
-      outPar.At(n,3,0) = std::abs(outPar.At(n,3,0));
+      Chg.At(n, 0, 0)  = -Chg.At(n, 0, 0);
+      outPar.At(n,3,0) = -outPar.At(n,3,0);
     }
   }
 }
@@ -724,8 +724,8 @@ void kalmanPropagateAndUpdateEndcap(const MPlexLS &psErr,  const MPlexLV& psPar,
   {
     if (outPar.At(n,3,0) < 0)
     {
-      Chg.At(n, 0, 0) = -1.0*Chg.ConstAt(n, 0, 0);
-      outPar.At(n,3,0) = std::abs(outPar.At(n,3,0));
+      Chg.At(n, 0, 0)  = -Chg.At(n, 0, 0);
+      outPar.At(n,3,0) = -outPar.At(n,3,0);
     }
   }
 }

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -1268,10 +1268,11 @@ void MkFinder::BkFitFitTracksBH(const EventOfHits   & eventofhits,
 
       if (CurHit[i] >= 0 && HoTArr[ i ][ CurHit[i] ].layer == layer)
       {
-        // Skip the overlap hit -- if it exists. Overlap hit gets placed *after* the
-        // original hit in TrackCand::exportTrack() -- which is *before* in the reverse
-        // iteration that we are doing here.
-        if (CurHit[i] > 0 && HoTArr[ i ][ CurHit[i] - 1 ].layer == layer) --CurHit[i];
+        // Skip the overlap hits -- if they exist.
+        // 1. Overlap hit gets placed *after* the original hit in TrackCand::exportTrack()
+        // which is *before* in the reverse iteration that we are doing here.
+        // 2. Seed-hit merging can result in more than two hits per layer.
+        while (CurHit[i] > 0 && HoTArr[ i ][ CurHit[i] - 1 ].layer == layer) --CurHit[i];
 
         const Hit &hit = L.GetHit( HoTArr[ i ][ CurHit[i] ].index );
         msErr.CopyIn(i, hit.errArray());

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -411,13 +411,10 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
       {
         const int pb = pi & L.m_phi_mask;
 
-	if (Config::useDeadModules)
+	if (L.m_phi_bin_deads[qi][pb] == true)
 	{
-	  if (L.m_phi_bin_deads[qi][pb] == true)
-	  {
-	    //std::cout << "dead module for track in layer=" << L.layer_id() << " qb=" << qi << " pb=" << pb << " q=" << q << " phi=" << phi<< std::endl;
-	    XWsrResult[itrack].m_in_gap = true;
-	  }
+	  //std::cout << "dead module for track in layer=" << L.layer_id() << " qb=" << qi << " pb=" << pb << " q=" << q << " phi=" << phi<< std::endl;
+	  XWsrResult[itrack].m_in_gap = true;
 	}
 
         // MT: The following line is the biggest hog (4% total run time).

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -411,10 +411,13 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
       {
         const int pb = pi & L.m_phi_mask;
 
-	if (L.m_phi_bin_deads[qi][pb] == true)
+	if (Config::useDeadModules)
 	{
-	  //std::cout << "dead module for track in layer=" << L.layer_id() << " qb=" << qi << " pb=" << pb << " q=" << q << " phi=" << phi<< std::endl;
-	  XWsrResult[itrack].m_in_gap = true;
+	  if (L.m_phi_bin_deads[qi][pb] == true)
+	  {
+	    //std::cout << "dead module for track in layer=" << L.layer_id() << " qb=" << qi << " pb=" << pb << " q=" << q << " phi=" << phi<< std::endl;
+	    XWsrResult[itrack].m_in_gap = true;
+	  }
 	}
 
         // MT: The following line is the biggest hog (4% total run time).

--- a/mkFit/MkStdSeqs.cc
+++ b/mkFit/MkStdSeqs.cc
@@ -282,8 +282,10 @@ int clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg)
             bool unique = true;
             for (int i = 0; i < tk.nTotalHits(); ++i)
             {
-              if ((hitidx == tk.getHitIdx(i)) && (hitlyr == tk.getHitLyr(i)))
+              if ((hitidx == tk.getHitIdx(i)) && (hitlyr == tk.getHitLyr(i))) {
                 unique = false;
+                break;
+              }
             }
             if (unique) {
               tk.addHitIdx(tk2.getHitIdx(j), tk2.getHitLyr(j), fakeChi2);
@@ -297,7 +299,7 @@ int clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg)
 
     if (writetrack[ts])
     {
-      if (n_ovlp_hits_added > 0 && ! itrcfg.m_requires_seed_hit_sorting)
+      if (n_ovlp_hits_added > 0)
         seeds[ts].sortHitsByLayer();
       cleanSeedTracks.emplace_back(seeds[ts]);
     }

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -558,6 +558,9 @@ int main(int argc, const char *argv[])
 	" **Duplicate removal options\n"
 	"  --remove-dup            run duplicate removal after building, using both hit and kinematic criteria (def: %s)\n"
 	"  --remove-dup-no-hit     run duplicate removal after building, using kinematic criteria only (def: %s)\n"
+        "\n"
+	" **Dead module (strip) option\n"
+	"  --use-dead-modules          run duplicate removal after building, using both hit and kinematic criteria (def: %s)\n"
 	"\n"
 	" **Additional options for building\n"
         "  --use-phiq-arr           use phi-Q arrays in select hit indices (def: %s)\n"
@@ -571,7 +574,7 @@ int main(int argc, const char *argv[])
 	"                             must enable: --dump-for-plots\n"
 	"  --dump-for-plots         make shell printouts for plots (def: %s)\n"
         "  --mtv-like-val           configure validation to emulate CMSSW MultiTrackValidator (MTV) (def: %s)\n"
-	"  --mtv-require-seeds           configure validation to emulate MTV but require sim tracks to be matched to seeds (def: %s)\n"
+	"  --mtv-require-seeds      configure validation to emulate MTV but require sim tracks to be matched to seeds (def: %s)\n"
 	"\n"
 	" **ROOT based options\n"
         "  --sim-val-for-cmssw      enable ROOT based validation for CMSSW tracks with simtracks as reference [eff, FR, DR] (def: %s)\n"
@@ -679,6 +682,8 @@ int main(int argc, const char *argv[])
 
 	b2a(Config::removeDuplicates && Config::useHitsForDuplicates),
 	b2a(Config::removeDuplicates && !Config::useHitsForDuplicates),
+
+	b2a(Config::useDeadModules),
 
 	b2a(Config::usePhiQArrays),
         b2a(Config::kludgeCmsHitErrors),
@@ -891,6 +896,10 @@ int main(int argc, const char *argv[])
     {
       Config::removeDuplicates = true;
       Config::useHitsForDuplicates = false;
+    }
+    else if(*i == "--use-dead-modules")
+    {
+      Config::useDeadModules = true;
     }
     else if(*i == "--kludge-cms-hit-errors")
     {

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -343,7 +343,9 @@ void test_standard()
 
 	std::vector<DeadVec> deadvectors(ev.layerHits_.size());
 #include "deadmodules.h"
-	StdSeq::LoadDeads(eoh, deadvectors);
+	if(Config::useDeadModules) {
+	  StdSeq::LoadDeads(eoh, deadvectors);
+	}
 
         double t_best[NT] = {0}, t_cur[NT];
         std::vector<double> t_cur_iter;

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -548,6 +548,7 @@ int main(int argc, const char *argv[])
         "  --build-std              run standard combinatorial building test (def: %s)\n"
         "  --build-ce               run clone engine combinatorial building test (def: %s)\n"
         "  --build-mimi             run clone engine on multiple-iteration test (def: %s)\n"
+        "  --num-iters-cmssw <int>  number of mimi iterations to run (def: set to 3 when --build-mimi is in effect, 0 otherwise)\n"
 	"\n"
 	" **Seeding options\n"
         "  --seed-input     <str>   which seed collecion used for building (def: %s)\n"
@@ -777,11 +778,6 @@ int main(int argc, const char *argv[])
       next_arg_or_die(mArgs, i);
       Config::nEvents = atoi(i->c_str());
     }
-    else if (*i == "--num-iters-cmssw")
-    {
-       next_arg_or_die(mArgs, i);
-       Config::nItersCMSSW = atoi(i->c_str());
-    }
     else if (*i == "--start-event")
     {
       next_arg_or_die(mArgs, i);
@@ -858,6 +854,11 @@ int main(int argc, const char *argv[])
     {
       g_run_build_all = false; g_run_build_cmssw = false; g_run_build_bh = false; g_run_build_std = false; g_run_build_ce = false; g_run_build_mimi = true;
       if (Config::nItersCMSSW == 0) Config::nItersCMSSW = 3;
+    }
+    else if (*i == "--num-iters-cmssw")
+    {
+       next_arg_or_die(mArgs, i);
+       Config::nItersCMSSW = atoi(i->c_str());
     }
     else if(*i == "--seed-input")
     {

--- a/val_scripts/validation-cmssw-benchmarks-multiiter.sh
+++ b/val_scripts/validation-cmssw-benchmarks-multiiter.sh
@@ -16,7 +16,7 @@ source xeon_scripts/common-variables.sh ${suite}
 source xeon_scripts/init-env.sh
 export MIMI="CE mimi"
 declare -a val_builds=(MIMI)
-nevents=500
+nevents=250
 
 ## Common file setup
 case ${inputBin} in 


### PR DESCRIPTION
(1) Local merge of PR #327 (solving existing conflicts):
- vs. devel, for intialStep: http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/SVA_pr327/simval_iter4/efficiency/
-> No visible change, as expected.
- vs. devel, for lowPtTripletStep: http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/SVA_pr327/simval_iter5/efficiency/
-> Very slight change, as expected (due to typo fix in cleaning parameters).

All other iterations, for both SIMVAL and SIMVALSEED: http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/SVA_pr327/

--> Will close PR #327 as this PR effectively replaces it.

(2) Add optionality for dead modules (in standalone mkFit):
- w/ dead modules vs. w/o dead modules, for initialStep (SIMVALSEED): http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/SVA_deadModulesOption/simvalseed_iter4/efficiency/
-> As expected, when dead modules are used efficiency is lower, despite # hits/ track is higher:
http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/SVA_deadModulesOption/simvalseed_iter4/quality/?match=nHits*fit_pt0p0

All other iterations, for both SIMVAL and SIMVALSEED: http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/SVA_deadModulesOption/
