### PR TITLE
sqrt in dr for endcap SelectHitIndices

### DIFF
--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -327,7 +327,7 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
       float dphi = calcdphi(dphi2, min_dphi);
 
       const float  r = std::sqrt(r2);
-      const float dr = std::abs(nSigmaR*(x*x*Err[iI].ConstAt(itrack, 0, 0) + y*y*Err[iI].ConstAt(itrack, 1, 1) + 2*x*y*Err[iI].ConstAt(itrack, 0, 1)) / r2);
+      const float dr = nSigmaR*std::sqrt(std::abs(x*x*Err[iI].ConstAt(itrack, 0, 0) + y*y*Err[iI].ConstAt(itrack, 1, 1) + 2*x*y*Err[iI].ConstAt(itrack, 0, 1)) / r2);
 
       ////// Disable correction
       //if (Config::useCMSGeom) // should be Config::finding_requires_propagation_to_hit_pos


### PR DESCRIPTION
this fixes the computation of the uncertainty on r in SelectHitIndices in the endcap region. Here, after a propagation to the nominal z, check if the state is in the sensitive region and look for bins in r,phi where the hits will be searched.

(Speculative/guessing)
- expect effects at the layer edges where prop states with real uncty below 1 cm becomes smaller due to squaring and the layer can be ignored
- expect also some effects on the r-phi bin selection

http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/ttbar50_CKF_vs_mkFit_pr334_drFix_98dbfd1/plots_ootb.html
- there is practically no effect on the efficiency
- the number of hits goes up a bit in the forward region, as can be seen in the hitsLayers for OOB allTracks
<img width="421" alt="image" src="https://user-images.githubusercontent.com/4676718/126841868-6d5bd3bb-21e1-4dfa-9c8d-fd4ae24735c5.png">



