### PR TITLE
temporary solution for the pixelPair and detachedTriplet

### DIFF
--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -380,6 +380,8 @@ namespace
     ii[5].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
     ii[5].set_dupclean_flag();
     ii[5].set_dupl_params(0.25, 0.05,0.05,0.05);
+    ii[5].set_qfilter_layers_flag();
+    ii[5].set_qfilter_layers_param(4);
     fill_hit_selection_windows_params(ii[5]);
 
     ii[6].Clone(ii[0]);
@@ -414,6 +416,10 @@ namespace
     ii[9].set_seed_cleaning_params(2.0, 0.135, 0.135, 0.135, 0.135, 0.135, 0.135, 0.135, 0.135);
     ii[9].set_dupclean_flag();
     ii[9].set_dupl_params(0.5, 0.03,0.05,0.05);
+    ii[9].set_qfilter_layers_flag();
+    ii[9].set_qfilter_layers_param(3);
+    ii[9].set_qfilter_pixhits_flag();
+    ii[9].set_qfilter_pixhits_param(4);
     fill_hit_selection_windows_params(ii[9]);
 
     if (verbose)

--- a/mkFit/IterationConfig.cc
+++ b/mkFit/IterationConfig.cc
@@ -59,8 +59,10 @@ ITCONF_DEFINE_TYPE_NON_INTRUSIVE(mkfit::IterationParams,
   /* float */   fracSharedHits,
   /* float */   drth_central,
   /* float */   drth_obarrel,
-  /* float */   drth_forward
-
+  /* float */   drth_forward,
+  /* int */     minHitsQF,
+  /* int */     minLayers,
+  /* int */     minHitsPixFilter 
 )
 
 ITCONF_DEFINE_TYPE_NON_INTRUSIVE(mkfit::IterationConfig,
@@ -70,6 +72,8 @@ ITCONF_DEFINE_TYPE_NON_INTRUSIVE(mkfit::IterationConfig,
   /* bool */                     m_requires_seed_hit_sorting,
   /* bool */                     m_require_quality_filter,
   /* bool */                     m_require_dupclean_tight,
+  /* bool */                     m_require_qfilter_layers,
+  /* bool */                     m_require_qfilter_pixhits,
   // /* int */                   m_n_regions,
   // /* vector<int> */           m_region_order,
   // /* vector<mkfit::SteeringParams> */      m_steering_params,

--- a/mkFit/IterationConfig.h
+++ b/mkFit/IterationConfig.h
@@ -116,10 +116,13 @@ public:
   float c_dzmax_el = 0.015;
 
   int minHitsQF = 4;
+  int minLayers = 3;
+  int minHitsPixFilter = 3;
   float fracSharedHits = 0.19;
   float drth_central = 0.001; 
   float drth_obarrel = 0.001;
   float drth_forward = 0.001;
+
 
 };
 
@@ -154,6 +157,8 @@ public:
   bool  m_requires_seed_hit_sorting = false;
   bool  m_require_quality_filter    = false;
   bool  m_require_dupclean_tight    = false;
+  bool  m_require_qfilter_pixhits   = false;
+  bool  m_require_qfilter_layers    = false;
 
   // Iteration parameters (could be a ptr)
   IterationParams                     m_params;
@@ -214,8 +219,27 @@ public:
       m_params.drth_obarrel=drthObarrel;
       m_params.drth_forward=drthForward;
   }  
-  
-  
+
+  void set_qfilter_layers_flag()
+  {
+     m_require_qfilter_layers=true;
+  }
+
+  void set_qfilter_layers_param(int nLayers)
+  {
+     m_params.minLayers=nLayers;
+  }
+
+  void set_qfilter_pixhits_flag()
+  {
+     m_require_qfilter_pixhits=true;
+  }
+
+  void set_qfilter_pixhits_param(int nHits)
+  {
+     m_params.minHitsPixFilter=nHits;
+  }
+
   void set_seed_cleaning_params(float pt_thr,
         float dzmax_bh, float drmax_bh,
 				float dzmax_bl, float drmax_bl,

--- a/mkFit/MkStdSeqs.cc
+++ b/mkFit/MkStdSeqs.cc
@@ -479,6 +479,28 @@ void quality_filter(TrackVec & tracks, const int nMinHits)
   }
 }
 
+void quality_filter_layers(TrackVec & tracks, const int nLayers)
+{
+   const auto ntracks = tracks.size();
+
+   std::vector<bool> goodtrack(ntracks, false);
+
+   for (auto itrack = 0U; itrack < ntracks; itrack++)
+   {
+
+     auto &trk = tracks[itrack];
+     auto layers = trk.nUniqueLayers();
+
+     if (layers >= nLayers) goodtrack[itrack]=true;
+
+   }
+   for (int itrack = ntracks-1; itrack >-1; itrack--)
+   {
+     if(!goodtrack[itrack]) tracks.erase(tracks.begin() + itrack);
+   }
+}
+
+
 void find_duplicates_sharedhits(TrackVec &tracks, const float fraction)
 {
   const auto ntracks = tracks.size();
@@ -640,6 +662,7 @@ void find_and_remove_duplicates(TrackVec &tracks, const IterationConfig &itconf)
   }
   else if(itconf.m_require_dupclean_tight) 
   {
+    if(itconf.m_require_qfilter_layers) quality_filter_layers(tracks, itconf.m_params.minLayers);
     find_duplicates_sharedhits_pixelseed(tracks, itconf.m_params.fracSharedHits, itconf.m_params.drth_central, itconf.m_params.drth_obarrel, itconf.m_params.drth_forward);
   }
   else

--- a/mkFit/MkStdSeqs.h
+++ b/mkFit/MkStdSeqs.h
@@ -32,6 +32,7 @@ namespace StdSeq
     void handle_duplicates(Event *m_event);
       
     void quality_filter(TrackVec &tracks, const int nMinHits);
+    void quality_filter_layers(TrackVec &tracks, const int nLayers);
     void find_duplicates_sharedhits(TrackVec &tracks, const float fraction);
     void find_duplicates_sharedhits_pixelseed(TrackVec &tracks, const float fraction, const float drth_central, const float drth_obarrel, const float drth_forward);
 

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -512,10 +512,10 @@ std::vector<double> runBtpCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuil
       builder.filter_comb_cands([&](const TrackCand &t)
         { return StdSeq::qfilter_n_hits(t, itconf.m_params.minHitsQF); });
     }
-    else if (itconf.m_track_algorithm==6)
+    else if (itconf.m_require_qfilter_pixhits)
     {
       builder.filter_comb_cands([&](const TrackCand &t)
-       { return StdSeq::qfilter_n_hits_pixseed(t, 3); });
+       { return StdSeq::qfilter_n_hits_pixseed(t, itconf.m_params.minHitsPixFilter); });
     }
 
     builder.select_best_comb_cands();
@@ -633,10 +633,10 @@ void run_OneIteration(const TrackerInfo& trackerInfo, const IterationConfig &itc
     builder.filter_comb_cands([&](const TrackCand &t)
       { return StdSeq::qfilter_n_hits(t, itconf.m_params.minHitsQF); });
   }
-  else if (itconf.m_track_algorithm==6)
+  else if (itconf.m_require_qfilter_pixhits)
   {
     builder.filter_comb_cands([&](const TrackCand &t)
-      { return StdSeq::qfilter_n_hits_pixseed(t, 3); });
+      { return StdSeq::qfilter_n_hits_pixseed(t, itconf.m_params.minHitsPixFilter); });
   }
 
   builder.select_best_comb_cands();


### PR DESCRIPTION
this is a temporary solution to reduce the fake rate while retaining most of the efficiency for the pixelPair and detachedTriplet iterations - it will be revisited depending on the track selection updates.
the solution consists in requiring 

- 3 layers + 4 hits for pixelPair
- 4 layers for the detachedTriplet

comparisons plots are here
http://uaf-8.t2.ucsd.edu/~legianni/PR_iterations_update/compare-detachedTriplet/
http://uaf-8.t2.ucsd.edu/~legianni/PR_iterations_update/compare-pixelPair/

the full validation before and after is also available (wtih cmssw as a reference)
before - http://uaf-8.t2.ucsd.edu/~legianni/PR_iterations_update/benchmarks_old/
after - http://uaf-8.t2.ucsd.edu/~legianni/PR_iterations_update/benchmarks_ok/