### PR TITLE
update dead module treatment to a more restrictive

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -165,7 +165,7 @@ namespace Config
   extern float XigridME[Config::nBinsZME][Config::nBinsRME];
 
   // This will become layer dependent (in bits). To be consistent with min_dphi.
-  static constexpr int m_nphi = 128;
+  static constexpr int m_nphi = 256;
 
   // config on Event
   /*MM: chi2Cut is now set in IterationsParams*/

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -150,8 +150,8 @@ public:
 
   // Testing bin filling
   static constexpr float m_fphi     = Config::m_nphi / Config::TwoPI;
-  static constexpr int   m_phi_mask = 0x7f;
-  static constexpr int   m_phi_bits = 7;
+  static constexpr int   m_phi_mask = 0xff;
+  static constexpr int   m_phi_bits = 8;
   static constexpr float m_fphi_fine      = 1024 / Config::TwoPI;
   static constexpr int   m_phi_mask_fine  = 0x3ff;
   static constexpr int   m_phi_bits_fine  = 10; //can't be more than 16

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -816,6 +816,7 @@ void MkFinder::FindCandidates(const LayerOfHits                   &layer_of_hits
   }
 
   dprintf("FindCandidates max hits to process=%d\n", maxSize);
+  int nHitsAdded[NN] {};
 
   for (int hit_cnt = 0; hit_cnt < maxSize; ++hit_cnt)
   {
@@ -879,6 +880,7 @@ void MkFinder::FindCandidates(const LayerOfHits                   &layer_of_hits
 	  dprint("chi2=" << chi2);
 	  if (chi2 < m_iteration_params->chi2Cut)
 	  {
+            nHitsAdded[itrack]++;
 	    dprint("chi2 cut passed, creating new candidate");
 	    // Create a new candidate and fill the tmp_candidates output vector.
             // QQQ only instantiate if it will pass, be better than N_best
@@ -928,7 +930,7 @@ void MkFinder::FindCandidates(const LayerOfHits                   &layer_of_hits
       fake_hit_idx = -3;
     }
     //now add fake hit for tracks that passsed through inactive modules
-    else if (XWsrResult[itrack].m_in_gap == true)
+    else if (XWsrResult[itrack].m_in_gap == true && nHitsAdded[itrack] == 0)
     {
       fake_hit_idx = -7;
     }

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -972,6 +972,7 @@ void MkFinder::FindCandidatesCloneEngine(const LayerOfHits &layer_of_hits, CandC
   }
 
   dprintf("FindCandidatesCloneEngine max hits to process=%d\n", maxSize);
+  int nHitsAdded[NN] {};
 
   for (int hit_cnt = 0; hit_cnt < maxSize; ++hit_cnt)
   {
@@ -1005,6 +1006,7 @@ void MkFinder::FindCandidatesCloneEngine(const LayerOfHits &layer_of_hits, CandC
         dprint("chi2=" << chi2 << " for trkIdx=" << itrack << " hitIdx=" << XHitArr.At(itrack, hit_cnt, 0));
         if (chi2 < m_iteration_params->chi2Cut)
         {
+          nHitsAdded[itrack]++;
           const int hit_idx = XHitArr.At(itrack, hit_cnt, 0);
 
           // Register hit for overlap consideration, here we apply chi2 cut
@@ -1055,7 +1057,7 @@ void MkFinder::FindCandidatesCloneEngine(const LayerOfHits &layer_of_hits, CandC
       fake_hit_idx = -3;
     }
     //now add fake hit for tracks that passsed through inactive modules
-    else if (XWsrResult[itrack].m_in_gap == true)
+    else if (XWsrResult[itrack].m_in_gap == true && nHitsAdded[itrack] == 0)
     {
       fake_hit_idx = -7;
     }

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -212,7 +212,7 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
            L.is_barrel() ? "barrel" : "endcap", L.layer_id(), N_proc);
 
   float dqv[NN], dphiv[NN], qv[NN], phiv[NN];
-  int qb1v[NN], qb2v[NN], pb1v[NN], pb2v[NN];
+  int qb1v[NN], qb2v[NN], qbv[NN], pb1v[NN], pb2v[NN];
 
   const auto assignbins = [&](int itrack, float q, float dq, float phi, float dphi, float min_dq, float max_dq, float min_dphi, float max_dphi){
     dphi = clamp(std::abs(dphi), min_dphi, max_dphi);
@@ -223,6 +223,7 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
     dphiv[itrack] = dphi;
     dqv[itrack]   = dq;
     //
+    qbv [itrack] = L.GetQBinChecked(q);
     qb1v[itrack] = L.GetQBinChecked(q - dq);
     qb2v[itrack] = L.GetQBinChecked(q + dq) + 1;
     pb1v[itrack] = L.GetPhiBin(phi - dphi);
@@ -361,6 +362,7 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
       continue;
     }
 
+    const int qb  = qbv [itrack];
     const int qb1 = qb1v[itrack];
     const int qb2 = qb2v[itrack];
     const int pb1 = pb1v[itrack];
@@ -411,7 +413,8 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
       {
         const int pb = pi & L.m_phi_mask;
 
-	if (L.m_phi_bin_deads[qi][pb] == true)
+        // Limit to central Q-bin
+        if (qi == qb && L.m_phi_bin_deads[qi][pb] == true)
 	{
 	  //std::cout << "dead module for track in layer=" << L.layer_id() << " qb=" << qi << " pb=" << pb << " q=" << q << " phi=" << phi<< std::endl;
 	  XWsrResult[itrack].m_in_gap = true;


### PR DESCRIPTION
- restrict addition of a gap/dead hit only if the candidate did not have other hits added
- q bin and phi bin updates from https://github.com/trackreco/mkFit/compare/deadmod-reduce-region
    - the q bin part is taken as is
    - the phi binning is updated just to 256

the validation and  choice for 256 phi bins is based on 
[mkFit_deadMod_080921.pdf](https://github.com/cms-sw/cms-sw.github.io/files/6962159/mkFit_deadMod_080921.pdf)
links to mtv plots:

- restriction based on hit count and qbin ("drFix" is the baseline without dead modules as of #335)
    - 10mu http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/10mu_mkFit_dr_dead-restrict_me082692_c19205b8
    - ttbar http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/ttbar50_mkFit_dr_dead-restrict_me082692_c19205b8
- bin variations
    - 10mu http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/10mu_mkFit_dr_dead-restricted-Qbin-p512_m7405a71_c19205b8
    - ttbar http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/ttbar50_mkFit_dr_dead-restricted-Qbin-p512_m7405a71_c19205b8

@leonardogiannini please check how the failure scenarios look like with this update.