### PR TITLE
add compatibility requirement for propagations to strip hits

### DIFF
--- a/mkFit/FindingFoos.h
+++ b/mkFit/FindingFoos.h
@@ -9,7 +9,7 @@ class MkBase;
 
 #define COMPUTE_CHI2_ARGS const MPlexLS &,  const MPlexLV &, const MPlexQI &, \
                           const MPlexHS &,  const MPlexHV &, \
-                          MPlexQF &,  const int, const PropagationFlags
+                                MPlexQF &,        MPlexLV &, const int, const PropagationFlags
 
 #define UPDATE_PARAM_ARGS const MPlexLS &,  const MPlexLV &, MPlexQI &, \
                           const MPlexHS &,  const MPlexHV &, \

--- a/mkFit/KalmanUtilsMPlex.cc
+++ b/mkFit/KalmanUtilsMPlex.cc
@@ -517,13 +517,13 @@ void kalmanComputeChi2(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQ
 
 void kalmanPropagateAndComputeChi2(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI &inChg,
                                    const MPlexHS &msErr,  const MPlexHV& msPar,
-                                         MPlexQF& outChi2,
+                                         MPlexQF& outChi2,      MPlexLV& propPar,
                                    const int      N_proc, const PropagationFlags propFlags)
 {
+  propPar = psPar;
   if (Config::finding_requires_propagation_to_hit_pos)
   {
     MPlexLS propErr;
-    MPlexLV propPar;
     MPlexQF msRad;
 #pragma omp simd
     for (int n = 0; n < NN; ++n)
@@ -743,13 +743,13 @@ void kalmanComputeChi2Endcap(const MPlexLS &psErr,  const MPlexLV& psPar, const 
 
 void kalmanPropagateAndComputeChi2Endcap(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI &inChg,
                                          const MPlexHS &msErr,  const MPlexHV& msPar,
-                                               MPlexQF& outChi2,
+                                               MPlexQF& outChi2,      MPlexLV& propPar,
                                          const int      N_proc, const PropagationFlags propFlags)
 {
+  propPar = psPar;
   if (Config::finding_requires_propagation_to_hit_pos)
   {
     MPlexLS propErr;
-    MPlexLV propPar;
     MPlexQF msZ;
 #pragma omp simd
     for (int n = 0; n < NN; ++n)

--- a/mkFit/KalmanUtilsMPlex.h
+++ b/mkFit/KalmanUtilsMPlex.h
@@ -35,7 +35,7 @@ void kalmanComputeChi2(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQ
 
 void kalmanPropagateAndComputeChi2(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI &inChg,
                                    const MPlexHS &msErr,  const MPlexHV& msPar,
-                                         MPlexQF& outChi2,
+                                         MPlexQF& outChi2,      MPlexLV& propPar,
                                    const int      N_proc, const PropagationFlags propFlags);
 
 
@@ -66,7 +66,7 @@ void kalmanComputeChi2Endcap(const MPlexLS &psErr,  const MPlexLV& psPar, const 
 
 void kalmanPropagateAndComputeChi2Endcap(const MPlexLS &psErr,  const MPlexLV& psPar, const MPlexQI &inChg,
                                          const MPlexHS &msErr,  const MPlexHV& msPar,
-                                               MPlexQF& outChi2,
+                                               MPlexQF& outChi2,      MPlexLV& propPar,
                                          const int      N_proc, const PropagationFlags propFlags);
 
 

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -1057,7 +1057,8 @@ void MkFinder::FindCandidatesCloneEngine(const LayerOfHits &layer_of_hits, CandC
               const float hitT2 = msErr.At(itrack,0,0) + msErr.At(itrack,1,1);
               const float hitT2inv = 1.f/hitT2;
               const float proj[3] = {msErr.At(itrack,0,0)*hitT2inv, msErr.At(itrack,0,1)*hitT2inv, msErr.At(itrack,1,1)*hitT2inv};
-              const float qErr = sqrt(Err[iP].At(itrack,0,0)+Err[iP].At(itrack,1,1));//this is not precise, but avoids decomposition
+              const float qErr = sqrt(std::abs(Err[iP].At(itrack,0,0)*proj[0] + 2.f*Err[iP].At(itrack,0,1)*proj[1] 
+                                               + Err[iP].At(itrack,1,1)*proj[2]));//take abs to avoid non-pos-def cases
               const float resProj = sqrt(res[0]*proj[0]*res[0] + 2.f*res[1]*proj[1]*res[0] + res[1]*proj[2]*res[1]);
               isCompatible = sqrt(hitT2*3.f) + std::max(3.f*qErr, 0.5f) > resProj;
               dprint("qCompat "<<isCompatible<<" "<< sqrt(hitT2*3.f) <<" + "<<3.f*qErr<<" vs "<<resProj);


### PR DESCRIPTION
The following condition is applied on `hit-prop` residuals to make sure that the propagation points consistently within the length bounds of the strip
- `strip hit half-length` + `3*sigma_propagation` > `residual_along_strip` 

More detail:
- the `strip half-length` is related to the uncertainty of its position, in the simplest case of a hit aligned along z, the hit uncertainty along z is `strip half-length` times `sqrt(3)`
- in the barrel the test is simply done in z direction
- in the endcaps the test is done by projecting on the longest component of the hit correlation matrix (taking an approximation that in x-y the uncertainty across the strip (around 100 µm) is negligible.

This is a bit of a kludge until we get the proper geometry details. The CKF tracking has a similar requirement.

Validation using `mkfit=all` and compiled with `AVX2:=1 USE_INTRINSICS:=-DMPT_SIZE=1`
- ttbar http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/ttbar50_mkFit-pr344-pr345-qCompat_m6787d91_c5e29902
- 10mu http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/10mu_mkFit-pr344-pr345-qCompat_m6787d91_c5e29902/plots_initialStep.html
    - here, for 10mu, the plots show that there is no efficiency or hit loss

In the following, screenshots are for built tracks from the initialStep in the ttbar PU50 sample
orange is the same as the latest physics performance in this PR (6787d91) and has a small improvement compared to black, which was shown during the Aug 27 meeting
<img width="1029" alt="image" src="https://user-images.githubusercontent.com/4676718/131206201-84751b7d-b3ba-4efd-8f1a-f453943ff366.png">

There is a small reduction in the number of hits due to rejection of fake hits
<img width="705" alt="image" src="https://user-images.githubusercontent.com/4676718/131206375-afab004b-8a0e-4dff-a3a6-c9229cb902eb.png">
The number of missing outer is a bit better
<img width="344" alt="image" src="https://user-images.githubusercontent.com/4676718/131206390-17b9f32e-078a-4881-9af9-4ed408a5bd03.png">


a comparison with CKF is available in http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/ttbar50_CKF_mkFit-pr344-pr345-qCompat_md94a476_c5e29902 (here `qCompat` is as of the earlier version shown in black in the `mkfit=all` comparisons above).

