### PR TITLE
back to BackwardFitBH for iters without bw search

### DIFF
--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -646,19 +646,29 @@ void run_OneIteration(const TrackerInfo& trackerInfo, const IterationConfig &itc
       { return StdSeq::qfilter_n_hits_pixseed(t, 3); });
   }
 
-  if (do_backward_fit)
-  {
-    builder.BackwardFit();
 
-    if (itconf.m_backward_search)
+  if (itconf.m_backward_search)
+  {
+    if (do_backward_fit)
     {
-      builder.BeginBkwSearch();
-      builder.FindTracksCloneEngine(SteeringParams::IT_BkwSearch);
-      builder.EndBkwSearch();
+        builder.BackwardFit();
+
+        builder.BeginBkwSearch();
+        builder.FindTracksCloneEngine(SteeringParams::IT_BkwSearch);
+        builder.EndBkwSearch();
     }
+    builder.export_best_comb_cands(out_tracks);
+  }
+  else
+  {
+    builder.select_best_comb_cands();
+    if (do_backward_fit)
+    {
+      builder.BackwardFitBH();
+    }
+    builder.export_tracks(out_tracks);
   }
 
-  builder.export_best_comb_cands(out_tracks);
 
   if (do_remove_duplicates)
   {

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -531,20 +531,23 @@ std::vector<double> runBtpCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuil
     // now do backwards fit... do we want to time this section?
     if (Config::backwardFit)
     {
-      // a) TrackVec version:
-      // builder.BackwardFitBH();
-
-      // b) Version that runs on CombCand / TrackCand
-      builder.BackwardFit();
-
-      if (Config::backwardSearch && itconf.m_backward_search)
+      if (!(Config::backwardSearch && itconf.m_backward_search))
       {
+        // a) TrackVec version:
+        builder.BackwardFitBH();
+      }
+      else
+      {
+        // b) Version that runs on CombCand / TrackCand
+        builder.BackwardFit();
+
         builder.BeginBkwSearch();
         builder.FindTracksCloneEngine(SteeringParams::IT_BkwSearch);
         builder.EndBkwSearch();
-      }
 
-      builder.select_best_comb_cands(true); // true -> clear m_tracks as they were already filled once above
+        builder.select_best_comb_cands(true); // true -> clear m_tracks as they were already filled once above
+      }
+      
 
       StdSeq::find_and_remove_duplicates(builder.ref_tracks_nc(), itconf);
       builder.export_tracks(ev.fitTracks_);


### PR DESCRIPTION
#345 was not in an obvious way supposed to modify the iterations without the backward search. This PR recovers that behavior.

plots are available for `mkfit=all` option compiled with `AVX2:=1 USE_INTRINSICS:=-DMPT_SIZE=1`
- ttbar http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/ttbar50_mkFit-pr344-pr345-bwNoSearchBH_m7852743_c5e29902
- 10mu http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/10mu_mkFit-pr344-pr345-bwNoSearchBH_m7852743_c5e29902

black (this PR) vs the reference as of #344 are clearly the same based on the ratio plots, e.g. in ttbar initialStep built tracks
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/4676718/131225247-70bab895-eacb-4f00-9a79-1e3a9c00cfa9.png">

If the change from #345 for e.g. this `initialStep` case was an improvement, I guess we'd be fine to pick it up. Since this is a regression (a clear increase in fakes), I propose to take this PR and then perhaps investigate if the non-BH solution can be improved (IIUC, it is more flexible).

@osschar 
I've updated both the `run_OneIteration` and `runBtpCe_MultiIter`, but the CMSSW MTV test covers only `run_OneIteration`. 
Please check and if that seems correct, perhaps consider merging.
