### PR TITLE
Bksearch fix

### DIFF
--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -1460,7 +1460,7 @@ void MkBuilder::find_tracks_load_seeds(const TrackVec &in_seeds)
   // m_tracks can be used for BkFit.
   m_tracks.clear();
 
-  m_event_of_comb_cands.Reset((int) in_seeds.size(), m_job->params().maxCandsPerSeed);
+  m_event_of_comb_cands.Reset((int) in_seeds.size(), m_job->max_max_cands());
 
   import_seeds(in_seeds, [&](const Track& seed, int region){ m_event_of_comb_cands.InsertSeed(seed, region); });
 }

--- a/mkFit/MkBuilder.h
+++ b/mkFit/MkBuilder.h
@@ -70,7 +70,11 @@ public:
 
   const auto& steering_params(int i) { return m_iter_config.m_steering_params[i]; }
 
-  const auto& params() const { return m_iter_config.m_params; }
+  const auto& params()     const { return m_iter_config.m_params; }
+  const auto& params_bks() const { return m_iter_config.m_backward_params; }
+
+  int max_max_cands() const
+  { return std::max(params().maxCandsPerSeed, params_bks().maxCandsPerSeed); }
 
   const std::vector<bool>* get_mask_for_layer(int layer)
   {

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -1488,10 +1488,14 @@ void MkFinder::BkFitFitTracks(const EventOfHits   & eventofhits,
 
       if (CurNode[i] >= 0 && HoTNodeArr[ i ][ CurNode[i] ].m_hot.layer == layer)
       {
-        // XXXX - this is now different - overlap info has not yet been exported
-
-        // XXXX Note if I remove this hit (i.e., m_hot.index = -1), the overlap might stay.
-        //      Need to account for this in exportTrack().
+        // Skip the overlap hits -- if they exist.
+        // 1. Overlap hit gets placed *after* the original hit in TrackCand::exportTrack()
+        // which is *before* in the reverse iteration that we are doing here.
+        // 2. Seed-hit merging can result in more than two hits per layer.
+        // while (CurHit[i] > 0 && HoTArr[ i ][ CurHit[i] - 1 ].layer == layer) --CurHit[i];
+        while (HoTNodeArr[ i ][ CurNode[i] ].m_prev_idx >= 0 &&
+               HoTNodeArr[ i ][ HoTNodeArr[ i ][ CurNode[i] ].m_prev_idx ].m_hot.layer == layer)
+          CurNode[i] = HoTNodeArr[ i ][ CurNode[i] ].m_prev_idx;
 
         const Hit &hit = L.GetHit( HoTNodeArr[ i ][ CurNode[i] ].m_hot.index );
 


### PR DESCRIPTION
1. This fixes an issue found in #345 - efficiency dropped and fakes were worse (slightly). See also #349.
BackwardFit was preferentially using overlap hits on a given layer (this has been corrected before in BackwardFitBH).
2. BackwardFit relies on all TrackCands being allocated in the same thread / VM segment (whatever vgather requires the address offsets to conform to). In CMSSW it was observed that jemalloc can lead to TrackCands being allocated in significantly different segments. To work around this, a combined-candidate memory pool (CcPool) has been added that pre-allocates memory for all CombCandidates and then just hands it out in EvenOfCombinedCandidates::Reset().

MTV validation plots: http://xrd-cache-1.t2.ucsd.edu/matevz/PKF/bks-und-ccand-fix.vs.devel/

P.S. No. 2 could also be used for other TrackCand related objects (and temporary vectors) but it is not easy to calculate the upper bound of their total memory usage.