### PR TITLE
Correct layer edges

### DIFF
--- a/TrackerInfo.h
+++ b/TrackerInfo.h
@@ -117,8 +117,6 @@ public:
 
   WSR_Result is_within_z_sensitive_region(float z, float dz) const
   {
-    /* float edgeCorr = 0.5f*(m_rout-m_rin)*m_zmax/m_rin; */
-    /* dz = dz + edgeCorr; */
     if (z > m_zmax + dz || z < m_zmin - dz)  return WSR_Result(WSR_Outside, false);
     if (z < m_zmax - dz && z > m_zmin + dz)  return WSR_Result(WSR_Inside,  false);
     return WSR_Result(WSR_Edge, false);
@@ -126,14 +124,11 @@ public:
 
   WSR_Result is_within_r_sensitive_region(float r, float dr) const
   {
-    /* float edgeCorr = std::abs(0.5f*(m_zmax-m_zmin)*m_rout/m_zmin); */
-    /* dr = dr + edgeCorr; */
     if (r > m_rout + dr || r < m_rin - dr)  return WSR_Result(WSR_Outside, false);
     if (r < m_rout - dr && r > m_rin + dr)
     {
       if (m_has_r_range_hole)
       {
-        /* dr = dr - edgeCorr* (1.f - edgeCorr*m_hole_r_max/m_rout); */
         if (r < m_hole_r_max - dr && r > m_hole_r_min + dr)  return WSR_Result(WSR_Outside, true);
         if (r < m_hole_r_max + dr && r > m_hole_r_min - dr ) return WSR_Result(WSR_Edge,    true);
       }

--- a/TrackerInfo.h
+++ b/TrackerInfo.h
@@ -117,8 +117,8 @@ public:
 
   WSR_Result is_within_z_sensitive_region(float z, float dz) const
   {
-    float edgeCorr = 0.5f*(m_rout-m_rin)*m_zmax/m_rin;
-    dz = dz + edgeCorr;
+    /* float edgeCorr = 0.5f*(m_rout-m_rin)*m_zmax/m_rin; */
+    /* dz = dz + edgeCorr; */
     if (z > m_zmax + dz || z < m_zmin - dz)  return WSR_Result(WSR_Outside, false);
     if (z < m_zmax - dz && z > m_zmin + dz)  return WSR_Result(WSR_Inside,  false);
     return WSR_Result(WSR_Edge, false);
@@ -126,14 +126,14 @@ public:
 
   WSR_Result is_within_r_sensitive_region(float r, float dr) const
   {
-    float edgeCorr = std::abs(0.5f*(m_zmax-m_zmin)*m_rout/m_zmin);
-    dr = dr + edgeCorr;
+    /* float edgeCorr = std::abs(0.5f*(m_zmax-m_zmin)*m_rout/m_zmin); */
+    /* dr = dr + edgeCorr; */
     if (r > m_rout + dr || r < m_rin - dr)  return WSR_Result(WSR_Outside, false);
     if (r < m_rout - dr && r > m_rin + dr)
     {
       if (m_has_r_range_hole)
       {
-        dr = dr - edgeCorr* (1.f - edgeCorr*m_hole_r_max/m_rout);
+        /* dr = dr - edgeCorr* (1.f - edgeCorr*m_hole_r_max/m_rout); */
         if (r < m_hole_r_max - dr && r > m_hole_r_min + dr)  return WSR_Result(WSR_Outside, true);
         if (r < m_hole_r_max + dr && r > m_hole_r_min - dr ) return WSR_Result(WSR_Edge,    true);
       }

--- a/TrackerInfo.h
+++ b/TrackerInfo.h
@@ -117,6 +117,8 @@ public:
 
   WSR_Result is_within_z_sensitive_region(float z, float dz) const
   {
+    float edgeCorr = 0.5f*(m_rout-m_rin)*m_zmax/m_rin;
+    dz = dz + edgeCorr;
     if (z > m_zmax + dz || z < m_zmin - dz)  return WSR_Result(WSR_Outside, false);
     if (z < m_zmax - dz && z > m_zmin + dz)  return WSR_Result(WSR_Inside,  false);
     return WSR_Result(WSR_Edge, false);
@@ -124,11 +126,14 @@ public:
 
   WSR_Result is_within_r_sensitive_region(float r, float dr) const
   {
+    float edgeCorr = std::abs(0.5f*(m_zmax-m_zmin)*m_rout/m_zmin);
+    dr = dr + edgeCorr;
     if (r > m_rout + dr || r < m_rin - dr)  return WSR_Result(WSR_Outside, false);
     if (r < m_rout - dr && r > m_rin + dr)
     {
       if (m_has_r_range_hole)
       {
+        dr = dr - edgeCorr* (1.f - edgeCorr*m_hole_r_max/m_rout);
         if (r < m_hole_r_max - dr && r > m_hole_r_min + dr)  return WSR_Result(WSR_Outside, true);
         if (r < m_hole_r_max + dr && r > m_hole_r_min - dr ) return WSR_Result(WSR_Edge,    true);
       }

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -294,7 +294,7 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
       float dphi = calcdphi(dphi2, min_dphi);
 
       const float z  = Par[iI].ConstAt(itrack, 2, 0);
-      const float dz = std::abs(nSigmaZ * std::sqrt(Err[iI].ConstAt(itrack, 2, 2)));
+      const float dz = std::abs(nSigmaZ * std::sqrt(Err[iI].ConstAt(itrack, 2, 2))) + std::abs(0.5f*(L.m_layer_info->m_rout-L.m_layer_info->m_rin)/std::tan(Par[iI].ConstAt(itrack, 5, 0)));
       // XXX-NUM-ERR above, Err(2,2) gets negative!
       
       ////// Disable correction
@@ -350,7 +350,7 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
       float dphi = calcdphi(dphi2, min_dphi);
 
       const float  r = std::sqrt(r2);
-      const float dr = nSigmaR*std::sqrt(std::abs(x*x*Err[iI].ConstAt(itrack, 0, 0) + y*y*Err[iI].ConstAt(itrack, 1, 1) + 2*x*y*Err[iI].ConstAt(itrack, 0, 1)) / r2);
+      const float dr = nSigmaR*std::sqrt(std::abs(x*x*Err[iI].ConstAt(itrack, 0, 0) + y*y*Err[iI].ConstAt(itrack, 1, 1) + 2*x*y*Err[iI].ConstAt(itrack, 0, 1)) / r2) + std::abs(0.5f*(L.m_layer_info->m_zmax-L.m_layer_info->m_zmin)*std::tan(Par[iI].ConstAt(itrack, 5, 0)));
 
       ////// Disable correction
       //if (Config::useCMSGeom) // should be Config::finding_requires_propagation_to_hit_pos

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -321,7 +321,7 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
       //  dphi += dist / r;
       //}
 
-      XWsrResult[itrack] = L.is_within_z_sensitive_region(z, dz + edgeCorr);
+      XWsrResult[itrack] = L.is_within_z_sensitive_region(z, std::sqrt(dz*dz + edgeCorr*edgeCorr) );
       assignbins(itrack, z, dz, phi, dphi, min_dq, max_dq, min_dphi, max_dphi);
     }
   }
@@ -370,7 +370,7 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
       //  dphi += std::abs(alpha);
       //}
 
-      XWsrResult[itrack] = L.is_within_r_sensitive_region(r, dr + edgeCorr);
+      XWsrResult[itrack] = L.is_within_r_sensitive_region(r, std::sqrt(dr*dr + edgeCorr*edgeCorr) );
       assignbins(itrack, r, dr, phi, dphi, min_dq, max_dq, min_dphi, max_dphi);
     }
   }

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -294,7 +294,8 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
       float dphi = calcdphi(dphi2, min_dphi);
 
       const float z  = Par[iI].ConstAt(itrack, 2, 0);
-      const float dz = std::abs(nSigmaZ * std::sqrt(Err[iI].ConstAt(itrack, 2, 2))) + std::abs(0.5f*(L.m_layer_info->m_rout-L.m_layer_info->m_rin)/std::tan(Par[iI].ConstAt(itrack, 5, 0)));
+      const float dz = std::abs(nSigmaZ * std::sqrt(Err[iI].ConstAt(itrack, 2, 2)));
+      const float edgeCorr = std::abs(0.5f*(L.m_layer_info->m_rout-L.m_layer_info->m_rin)/std::tan(Par[iI].ConstAt(itrack, 5, 0)));
       // XXX-NUM-ERR above, Err(2,2) gets negative!
       
       ////// Disable correction
@@ -320,7 +321,7 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
       //  dphi += dist / r;
       //}
 
-      XWsrResult[itrack] = L.is_within_z_sensitive_region(z, dz);
+      XWsrResult[itrack] = L.is_within_z_sensitive_region(z, dz + edgeCorr);
       assignbins(itrack, z, dz, phi, dphi, min_dq, max_dq, min_dphi, max_dphi);
     }
   }
@@ -350,7 +351,8 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
       float dphi = calcdphi(dphi2, min_dphi);
 
       const float  r = std::sqrt(r2);
-      const float dr = nSigmaR*std::sqrt(std::abs(x*x*Err[iI].ConstAt(itrack, 0, 0) + y*y*Err[iI].ConstAt(itrack, 1, 1) + 2*x*y*Err[iI].ConstAt(itrack, 0, 1)) / r2) + std::abs(0.5f*(L.m_layer_info->m_zmax-L.m_layer_info->m_zmin)*std::tan(Par[iI].ConstAt(itrack, 5, 0)));
+      const float dr = nSigmaR*std::sqrt(std::abs(x*x*Err[iI].ConstAt(itrack, 0, 0) + y*y*Err[iI].ConstAt(itrack, 1, 1) + 2*x*y*Err[iI].ConstAt(itrack, 0, 1)) / r2);
+      const float edgeCorr = std::abs(0.5f*(L.m_layer_info->m_zmax-L.m_layer_info->m_zmin)*std::tan(Par[iI].ConstAt(itrack, 5, 0)));
 
       ////// Disable correction
       //if (Config::useCMSGeom) // should be Config::finding_requires_propagation_to_hit_pos
@@ -368,7 +370,7 @@ void MkFinder::SelectHitIndices(const LayerOfHits &layer_of_hits,
       //  dphi += std::abs(alpha);
       //}
 
-      XWsrResult[itrack] = L.is_within_r_sensitive_region(r, dr);
+      XWsrResult[itrack] = L.is_within_r_sensitive_region(r, dr + edgeCorr);
       assignbins(itrack, r, dr, phi, dphi, min_dq, max_dq, min_dphi, max_dphi);
     }
   }

--- a/mkFit/PropagationMPlex.cc
+++ b/mkFit/PropagationMPlex.cc
@@ -668,14 +668,14 @@ void helixAtZ(const MPlexLV& inPar,  const MPlexQI& inChg, const MPlexQF &msZ,
 		<< " pxin=" << pxin << " pyin=" << pyin);
 
       const float pxcaMpysa = pxin*cosa - pyin*sina;
-      errorProp(n,0,2) = -tanT * ipt * pxcaMpysa;;
-      errorProp(n,0,3) = 2*k*pt*pt*sinah*(sinP*sinah - cosP*cosah) + deltaZ*tanT*pxcaMpysa;
+      errorProp(n,0,2) = -tanT * ipt * pxcaMpysa;
+      errorProp(n,0,3) = k*pt*pt*( cosP*(alpha*cosa - sina) + sinP*( 1.f - cosa - alpha*sina) );
       errorProp(n,0,4) = -2*k*pt*sinah*(sinP*cosah + cosP*sinah);
       errorProp(n,0,5) = deltaZ*ipt*pxcaMpysa*icos2T;
 
       const float pycaPpxsa = pyin*cosa + pxin*sina;
       errorProp(n,1,2) = -tanT * ipt * pycaPpxsa;
-      errorProp(n,1,3) = -2*k*pt*pt*sinah*(sinP*cosah + cosP*sinah) + deltaZ*tanT*pycaPpxsa;
+      errorProp(n,1,3) = k*pt*pt*( sinP*(alpha*cosa - sina) - cosP*(1.f - cosa - alpha*sina) );
       errorProp(n,1,4) = 2*k*pt*sinah*(cosP*cosah - sinP*sinah);
       errorProp(n,1,5) = deltaZ*ipt*pycaPpxsa*icos2T;
 

--- a/mkFit/PropagationMPlex.cc
+++ b/mkFit/PropagationMPlex.cc
@@ -669,13 +669,13 @@ void helixAtZ(const MPlexLV& inPar,  const MPlexQI& inChg, const MPlexQF &msZ,
 
       const float pxcaMpysa = pxin*cosa - pyin*sina;
       errorProp(n,0,2) = -tanT * ipt * pxcaMpysa;
-      errorProp(n,0,3) = k*pt*pt*( cosP*(alpha*cosa - sina) + sinP*( 1.f - cosa - alpha*sina) );
+      errorProp(n,0,3) = k*pt*pt*( cosP*(alpha*cosa - sina) + sinP*2.f*sinah*(sinah - alpha*cosah) );
       errorProp(n,0,4) = -2*k*pt*sinah*(sinP*cosah + cosP*sinah);
       errorProp(n,0,5) = deltaZ*ipt*pxcaMpysa*icos2T;
 
       const float pycaPpxsa = pyin*cosa + pxin*sina;
       errorProp(n,1,2) = -tanT * ipt * pycaPpxsa;
-      errorProp(n,1,3) = k*pt*pt*( sinP*(alpha*cosa - sina) - cosP*(1.f - cosa - alpha*sina) );
+      errorProp(n,1,3) = k*pt*pt*( sinP*(alpha*cosa - sina) - cosP*2.f*sinah*(sinah - alpha*cosah) );
       errorProp(n,1,4) = 2*k*pt*sinah*(cosP*cosah - sinP*sinah);
       errorProp(n,1,5) = deltaZ*ipt*pycaPpxsa*icos2T;
 


### PR DESCRIPTION
This PR corrects the layer edges for the layer spread in r (z) for barrel (endcap).
The implementation is preliminary (currently all in SelectHitIndices and summing linearly the correction to dz or dr), comments are welcome.
The number of layers in the transition region is significantly improved in the high pT 10mu sample:
http://uaf-8.t2.ucsd.edu/~cerati/plots_Sep08_10mu_testzfix_edge2_gcc/plots_building_initialStep/hitsLayers.pdf
This comes at a price of some increase in fake rate in ttbar:
http://uaf-8.t2.ucsd.edu/~cerati/plots_Sep08_ttbar_testzfix_edge2_gcc/plots_building_initialStep/effandfakePtEtaPhi.pdf
but also an increase in number of layers:
http://uaf-8.t2.ucsd.edu/~cerati/plots_Sep08_ttbar_testzfix_edge2_gcc/plots_building_initialStep/hitsLayers.pdf
Based on the increase in fake rate this may be something we don't want to merge immediately but eventually we should.

It also refactors the terms in the helixAtZ error propagation, for better numerical stability, and removes a double semicolon introduced in my previous PR. 
The effect is small, as expected: http://uaf-8.t2.ucsd.edu/~cerati/plots_Sep08_10mu_testzfixv2_edge2_gcc/plots_building_initialStep/hitsLayers.pdf