### PR TITLE
lowpt ranking tuning

### DIFF
--- a/Track.h
+++ b/Track.h
@@ -645,7 +645,7 @@ inline float getScoreCalc(const int nfoundhits,
                           const int nmisshits,
                           const float chi2,
                           const float pt,
-                          const bool lowPtTuneSpecial=false)
+                          const bool inFindCandidates=false)
 {
   //// Do not allow for chi2<0 in score calculation
   // if(chi2<0) chi2=0.f;
@@ -656,14 +656,14 @@ inline float getScoreCalc(const int nfoundhits,
   float tailPenalty = Config::tailMissingHitPenalty_;
   float overlapBonus = Config::overlapHitBonus_;
   if(pt < 0.9){
-    penalty *= lowPtTuneSpecial ? 1.7f : 1.5f;
-    bonus = std::min(bonus*(lowPtTuneSpecial ? 0.9f : 1.0f), maxBonus);
+    penalty *= inFindCandidates ? 1.7f : 1.5f;
+    bonus = std::min(bonus*(inFindCandidates ? 0.9f : 1.0f), maxBonus);
   }
   float score_ = bonus*nfoundhits + overlapBonus*noverlaphits - penalty*nmisshits - tailPenalty*ntailholes - chi2;
   return score_;
 }
 
- inline float getScoreCand(const Track& cand1, bool penalizeTailMissHits=false)
+ inline float getScoreCand(const Track& cand1, bool penalizeTailMissHits=false, bool inFindCandidates=false)
  {
    int nfoundhits = cand1.nFoundHits();
    int noverlaphits = cand1.nOverlapHits();
@@ -673,7 +673,7 @@ inline float getScoreCalc(const int nfoundhits,
    float chi2 = cand1.chi2();
    // Do not allow for chi2<0 in score calculation  
    if(chi2<0) chi2=0.f;
-   return getScoreCalc(nfoundhits,ntailmisshits,noverlaphits,nmisshits,chi2,pt,false);
+   return getScoreCalc(nfoundhits,ntailmisshits,noverlaphits,nmisshits,chi2,pt,inFindCandidates);
  }
 
 inline float getScoreStruct(const IdxChi2List& cand1)
@@ -686,7 +686,7 @@ inline float getScoreStruct(const IdxChi2List& cand1)
   float chi2 = cand1.chi2;
   // Do not allow for chi2<0 in score calculation
   if(chi2<0) chi2=0.f;
-  return getScoreCalc(nfoundhits,ntailholes,noverlaphits,nmisshits,chi2,pt,true);
+  return getScoreCalc(nfoundhits,ntailholes,noverlaphits,nmisshits,chi2,pt,true/*inFindCandidates*/);
 }
 
 

--- a/Track.h
+++ b/Track.h
@@ -644,7 +644,8 @@ inline float getScoreCalc(const int nfoundhits,
                           const int noverlaphits,
                           const int nmisshits,
                           const float chi2,
-                          const float pt)
+                          const float pt,
+                          const bool lowPtTuneSpecial=false)
 {
   //// Do not allow for chi2<0 in score calculation
   // if(chi2<0) chi2=0.f;
@@ -655,8 +656,8 @@ inline float getScoreCalc(const int nfoundhits,
   float tailPenalty = Config::tailMissingHitPenalty_;
   float overlapBonus = Config::overlapHitBonus_;
   if(pt < 0.9){
-    penalty *= 1.7f;
-    bonus = std::min(bonus*0.9f, maxBonus);
+    penalty *= lowPtTuneSpecial ? 1.7f : 1.5f;
+    bonus = std::min(bonus*(lowPtTuneSpecial ? 0.9f : 1.0f), maxBonus);
   }
   float score_ = bonus*nfoundhits + overlapBonus*noverlaphits - penalty*nmisshits - tailPenalty*ntailholes - chi2;
   return score_;
@@ -672,7 +673,7 @@ inline float getScoreCalc(const int nfoundhits,
    float chi2 = cand1.chi2();
    // Do not allow for chi2<0 in score calculation  
    if(chi2<0) chi2=0.f;
-   return getScoreCalc(nfoundhits,ntailmisshits,noverlaphits,nmisshits,chi2,pt);
+   return getScoreCalc(nfoundhits,ntailmisshits,noverlaphits,nmisshits,chi2,pt,false);
  }
 
 inline float getScoreStruct(const IdxChi2List& cand1)
@@ -685,7 +686,7 @@ inline float getScoreStruct(const IdxChi2List& cand1)
   float chi2 = cand1.chi2;
   // Do not allow for chi2<0 in score calculation
   if(chi2<0) chi2=0.f;
-  return getScoreCalc(nfoundhits,ntailholes,noverlaphits,nmisshits,chi2,pt);
+  return getScoreCalc(nfoundhits,ntailholes,noverlaphits,nmisshits,chi2,pt,true);
 }
 
 

--- a/Track.h
+++ b/Track.h
@@ -652,11 +652,13 @@ inline float getScoreCalc(const int nfoundhits,
   float maxBonus = 8.0;
   float bonus  = Config::validHitSlope_*nfoundhits + Config::validHitBonus_;
   float penalty = Config::missingHitPenalty_;
+  float tailPenalty = Config::tailMissingHitPenalty_;
+  float overlapBonus = Config::overlapHitBonus_;
   if(pt < 0.9){
-    penalty += 0.5*Config::missingHitPenalty_; 
-    bonus = std::min(bonus, maxBonus);
+    penalty *= 1.7f;
+    bonus = std::min(bonus*0.9f, maxBonus);
   }
-  float score_ = bonus*nfoundhits + Config::overlapHitBonus_*noverlaphits - penalty*nmisshits - Config::tailMissingHitPenalty_*ntailholes - chi2;
+  float score_ = bonus*nfoundhits + overlapBonus*noverlaphits - penalty*nmisshits - tailPenalty*ntailholes - chi2;
   return score_;
 }
 

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -535,7 +535,7 @@ inline bool sortByScoreTrackCand(const TrackCand & cand1, const TrackCand & cand
   return cand1.score() > cand2.score();
 }
 
-inline float getScoreCand(const TrackCand& cand1, bool penalizeTailMissHits=false)
+inline float getScoreCand(const TrackCand& cand1, bool penalizeTailMissHits=false, bool inFindCandidates=false)
 {
   int nfoundhits   = cand1.nFoundHits();
   int noverlaphits = cand1.nOverlapHits();
@@ -545,7 +545,7 @@ inline float getScoreCand(const TrackCand& cand1, bool penalizeTailMissHits=fals
   float chi2 = cand1.chi2();
   // Do not allow for chi2<0 in score calculation
   if (chi2 < 0) chi2 = 0.f;
-  return getScoreCalc(nfoundhits,ntailmisshits, noverlaphits, nmisshits, chi2, pt);
+  return getScoreCalc(nfoundhits,ntailmisshits, noverlaphits, nmisshits, chi2, pt, inFindCandidates);
 }
 
 

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -963,7 +963,7 @@ void MkFinder::FindCandidates(const LayerOfHits                   &layer_of_hits
               copy_out(newcand, itrack, iC);
               newcand.setCharge(tmpChg(itrack, 0, 0));
               newcand.addHitIdx(hit_idx, layer_of_hits.layer_id(), chi2);
-              newcand.setScore(getScoreCand(newcand, true));
+              newcand.setScore(getScoreCand(newcand, true/*penalizeTailMissHits*/, true/*inFindCandidates*/));
               newcand.setOriginIndex(CandIdx(itrack, 0, 0));
               
               if (chi2 < m_iteration_params->chi2CutOverlap)
@@ -1014,7 +1014,7 @@ void MkFinder::FindCandidates(const LayerOfHits                   &layer_of_hits
     TrackCand newcand;
     copy_out(newcand, itrack, iP);
     newcand.addHitIdx(fake_hit_idx, layer_of_hits.layer_id(), 0.);
-    newcand.setScore(getScoreCand(newcand, true));
+    newcand.setScore(getScoreCand(newcand, true/*penalizeTailMissHits*/, true/*inFindCandidates*/));
     // Only relevant when we actually add a hit
     // newcand.setOriginIndex(CandIdx(itrack, 0, 0));
     tmp_candidates[SeedIdx(itrack, 0, 0) - offset].emplace_back(newcand);


### PR DESCRIPTION
The ranking is updated for low pt (pt < 0.9) :
- penalty from `*= 1.5` to `*= 1.7` of the high pt
- found hit bonus from `*= 1.0` to `*= 0.9` of the high pt

This update is applied only during building (as in this PR it was checked for the clone-engine) in `getScoreStruct` method.

The tuning was made based on the initialStep built tracks; the figures of merit considered were the fakerate (decrease) while the number of hits on track is kept from dropping much. More significant changes appear to reduce the number of hits by too much. The original scan of values was done in devel as of #351 and then checked to be consistent on top of #355 as well.

### Performance for a few close points
 (black is what's proposed in this PR): the fake rate goes down fractionally by 20%
http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/ttbar50_CKF_mkFit-pr355_lowpt-penalty1.7-bonus1.0-tailPenalty1.0_m7b132b5_cb49b711/plots_initialStep.html
<img width="964" alt="image" src="https://user-images.githubusercontent.com/4676718/133638082-871932e9-74e1-4cb7-895c-253efc7a3314.png">
The reduction in the number of hits is perhaps still manageable
<img width="911" alt="image" src="https://user-images.githubusercontent.com/4676718/133638508-cec27f51-015e-4bd3-8806-a32f9150dedb.png">

Compared to ttbar the number of hits in the 0.2-1GeV muon sample is reduced by about a factor of 2 less
http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/10muvlow_CKF_mkFit-pr355_lowpt-penalty1.7-bonus0.9-tailPenalty1.0_m9fde252_cb49b711/plots_initialStep.html
<img width="911" alt="image" src="https://user-images.githubusercontent.com/4676718/133828108-3bcdd183-47cb-4cf9-91f3-907f33a2aa5f.png">

### After the general tuning, 
the options of applying this update only during building vs the final candidate scoring was checked. 
Most of the change in the fake rate is from retuning the building part 
http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/ttbar50_CKF_mkFit-pr355_lowpt-penalty1.7-bonus0.9-tailPenalty1.0_inCands_m42e27aa_cb49b711/plots_initialStep.html
<img width="962" alt="image" src="https://user-images.githubusercontent.com/4676718/133889223-094e4cdf-a386-427d-a1be-c1b571ad4a58.png">
while just slightly less than a half of the hit loss for vlowpt muons is from the building part (delta mean nhtis -0.08 from building (red -orange), vs -0.11 from the final cand scoring)
http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/10muvlow_CKF_mkFit-pr355_lowpt-penalty1.7-bonus0.9-tailPenalty1.0_inCands_m42e27aa_cb49b711/plots_initialStep.html
<img width="886" alt="image" src="https://user-images.githubusercontent.com/4676718/133889265-4d7f239a-34e7-49a7-a141-6e691cd82968.png">


### The combined performance 
#### in the mkfit "4" iteration variant out of the box:
http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/ttbar50_CKF_mkFit-4-pr355_lowpt-penalty1.7-bonus0.9-tailPenalty1.0_inStruct_m66c5ff6_cb49b711/plots_ootb.html
all tracks
<img width="964" alt="image" src="https://user-images.githubusercontent.com/4676718/133898345-0f126670-01e3-40ea-829d-15e5587165f1.png">
there is in fact a small increase in the duplicate rate
<img width="911" alt="image" src="https://user-images.githubusercontent.com/4676718/133898371-06d01d34-eeaf-4ed1-a593-682b4f2f84d5.png">

High purity tracks
<img width="917" alt="image" src="https://user-images.githubusercontent.com/4676718/133898402-ddf6b1b1-70e1-4c42-9efd-7310e13cff8e.png">


#### In the mkfit 7-iter variant 
http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/ttbar50_CKF_mkFit-7-pr355_lowpt-penalty1.7-bonus0.9-tailPenalty1.0_inStruct_m66c5ff6_cb49b711/plots_ootb.html
OOB all tracks the changes are somewhat similar; the relative reduction in the fake rate by about 6% at a cost of 0.07 hit
<img width="921" alt="image" src="https://user-images.githubusercontent.com/4676718/133898449-da5e32cf-b981-480c-9a02-440e246781f7.png">
<img width="960" alt="image" src="https://user-images.githubusercontent.com/4676718/133898494-a4a286d2-2d2c-432a-a1e3-03f81fda8a99.png">

similarly for high purity:
the fake rate is now on average below CKF
<img width="923" alt="image" src="https://user-images.githubusercontent.com/4676718/133898517-6aae3f8c-eaf5-4e73-a6b7-42c481452568.png">

<img width="912" alt="image" src="https://user-images.githubusercontent.com/4676718/133898540-04301191-f819-49ef-b6a7-52c825ec5a0e.png">



