### PR TITLE
Cluster size cuts

### DIFF
--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -246,6 +246,35 @@ namespace
     }
   }
 
+  void fill_cluster_size_cuts(IterationsInfo& ii)
+  {
+    int clszcuts[10][72];
+    for (size_t i=0; i<10; i++) {
+      for (size_t l=0; l<72; l++) {
+	if (i==0) {
+	  //first iteration, 95% working point
+	  if (l<4)                                   clszcuts[i][l] = 999;//PXB
+	  else if ((l>17 && l<21) || (l>44 && l<48)) clszcuts[i][l] = 999;//PXF
+	  else if ( l>3  && l<10 )                   clszcuts[i][l] = 4;  //TIB
+	  else if ((l>20 && l<27) || (l>47 && l<54)) clszcuts[i][l] = 4;  //TID
+	  else if ( l>9  && l<18 )                   clszcuts[i][l] = 999;//TOB
+	  else if ((l>26 && l<45) || (l>53 && l<72)) clszcuts[i][l] = 5;  //TEC
+	  else clszcuts[i][l] = 999;
+	} else {
+	  //not implemented for other iterations
+	  clszcuts[i][l] = 999;
+	}
+      }
+    }
+
+    for (int j=0; j<ii.size(); j++) {
+      IterationConfig& ic = ii[j];
+      for (size_t l=0; l<ic.m_layer_configs.size(); l++) {
+	ic.m_layer_configs[l].clrowcut = clszcuts[j][l];
+      }
+    }
+  }
+
   std::function<IterationConfig::partition_seeds_foo> PartitionSeeds0 =
   [](const TrackerInfo &trk_info, const TrackVec &in_seeds, const EventOfHits &eoh,
      IterationSeedPartition &part)
@@ -453,6 +482,8 @@ namespace
     ii[9].set_dupl_params(0.5, 0.03,0.05,0.05);
     fill_hit_selection_windows_params(ii[9]);
     ii[9].m_backward_params = ii[9].m_params;
+
+    fill_cluster_size_cuts(ii);
 
     if (verbose)
     {

--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -255,10 +255,10 @@ namespace
 	  //first iteration, 95% working point
 	  if (l<4)                                   clszcuts[i][l] = 999;//PXB
 	  else if ((l>17 && l<21) || (l>44 && l<48)) clszcuts[i][l] = 999;//PXF
-	  else if ( l>3  && l<10 )                   clszcuts[i][l] = 4;  //TIB
-	  else if ((l>20 && l<27) || (l>47 && l<54)) clszcuts[i][l] = 4;  //TID
+	  else if ( l>3  && l<10 )                   clszcuts[i][l] = 5;  //TIB
+	  else if ((l>20 && l<27) || (l>47 && l<54)) clszcuts[i][l] = 5;  //TID
 	  else if ( l>9  && l<18 )                   clszcuts[i][l] = 999;//TOB
-	  else if ((l>26 && l<45) || (l>53 && l<72)) clszcuts[i][l] = 5;  //TEC
+	  else if ((l>26 && l<45) || (l>53 && l<72)) clszcuts[i][l] = 7;  //TEC
 	  else clszcuts[i][l] = 999;
 	} else {
 	  //not implemented for other iterations

--- a/mkFit/IterationConfig.cc
+++ b/mkFit/IterationConfig.cc
@@ -36,7 +36,8 @@ ITCONF_DEFINE_TYPE_NON_INTRUSIVE(mkfit::IterationLayerConfig,
   /* float */   c_c2_sf,
   /* float */   c_c2_0,
   /* float */   c_c2_1,
-  /* float */   c_c2_2
+  /* float */   c_c2_2,
+  /* unsigned int */ clrowcut
 )
 
 ITCONF_DEFINE_TYPE_NON_INTRUSIVE(mkfit::IterationParams,

--- a/mkFit/IterationConfig.h
+++ b/mkFit/IterationConfig.h
@@ -82,6 +82,8 @@ public:
 
   //----------------------------------------------------------------------------
 
+  unsigned int clrowcut;
+
   IterationLayerConfig() {}
 };
 

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -1092,6 +1092,8 @@ void MkFinder::FindCandidatesCloneEngine(const LayerOfHits &layer_of_hits, CandC
           if (!layer_of_hits.is_pix_lyr()) {//check module compatibility via long strip side = L/sqrt(12)
             isCompatible = isStripQCompatible(itrack, layer_of_hits.is_barrel(), Err[iP], propPar, msErr, msPar);
           }
+	  //check cluster size compatibility, rows for now (strips - need to add also cols in case we want it for pixels too)
+	  if (layer_of_hits.GetHit( XHitArr.At(itrack, hit_cnt, 0) ).spanRows() > m_iteration_layer_config->clrowcut) isCompatible = false;
 
           if (isCompatible) {
 


### PR DESCRIPTION
Add option for cluster row size cut (iteration and layer-dependent), and turn it on for InitialStep.

Tested on initialStep within MTV:
http://uaf-8.t2.ucsd.edu/~cerati/plots_Sep16_ttbar_clshcut_PR/plots_initialStep.html

A PR to CMSSW with JSON updates will also be needed.