### PR TITLE
retuned detachedTriplet

### DIFF
--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -414,7 +414,7 @@ namespace
     ii[5].set_iteration_index_and_track_algorithm(5, (int) TrackBase::TrackAlgorithm::detachedTripletStep);
     ii[5].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
     ii[5].set_dupclean_flag();
-    ii[5].set_dupl_params(0.25, 0.05,0.05,0.05);
+    ii[5].set_dupl_params(0.59, 0.01,0.01,0.1);
     fill_hit_selection_windows_params(ii[5]);
     ii[5].m_backward_params = ii[5].m_params;
 

--- a/mkFit/MkStdSeqs.cc
+++ b/mkFit/MkStdSeqs.cc
@@ -456,52 +456,24 @@ void handle_duplicates(Event *m_event)
 
 void quality_filter(TrackVec & tracks, const int nMinHits)
 {
-  const auto ntracks = tracks.size();
-
-  std::vector<bool> goodtrack(ntracks, false);
-
-  for (auto itrack = 0U; itrack < ntracks; itrack++)
-  {
-    auto &trk = tracks[itrack];
-
+  tracks.erase(std::remove_if(tracks.begin(), tracks.end(), [nMinHits](auto &trk) {
     auto seedHits = trk.getNSeedHits();
     auto seedReduction = (seedHits <= 5) ? 2 : 3;
 
-    // minimum 4 hits 
-    if (trk.nFoundHits() - seedReduction >= nMinHits) goodtrack[itrack]=true;
-    //penalty (not used)
-    //if (trk.nFoundHits()-seedReduction>=4+(seedHits==4)) goodtrack[itrack]=true;
-  }
-
-  for (auto itrack = ntracks-1; itrack >0; itrack--)
-  {
-    if(!goodtrack[itrack]) tracks.erase(tracks.begin() + itrack);
-  }
+    return trk.nFoundHits() - seedReduction < nMinHits;
+  }), tracks.end());
 }
 
 void quality_filter_layers(TrackVec & tracks)
 {
-    const auto ntracks = tracks.size();
- 
-    std::vector<bool> goodtrack(ntracks, true);
- 
-    for (auto itrack = 0U; itrack < ntracks; itrack++)
-    {
- 
-      auto &trk = tracks[itrack];
-      auto layers = trk.nUniqueLayers();
-      auto llyr   = trk.getLastFoundHitLyr();
-      auto nhits  = trk.nFoundHits();
- 
-      if(nhits==3 && (llyr==2||llyr==18||llyr==45)) goodtrack[itrack]=false;
-      if(layers==3 && (llyr==2||llyr==18||llyr==45)) goodtrack[itrack]=false;
-      //if (layers >= nLayers) goodtrack[itrack]=true;
- 
-    }
-    for (int itrack = ntracks-1; itrack >-1; itrack--)
-    {
-      if(!goodtrack[itrack]) tracks.erase(tracks.begin() + itrack);
-    }
+  tracks.erase(std::remove_if(tracks.begin(), tracks.end(), [](auto &trk) {
+    auto layers = trk.nUniqueLayers();
+    auto llyr   = trk.getLastFoundHitLyr();
+    auto nhits  = trk.nFoundHits();
+
+    return (nhits ==3 && (llyr==2||llyr==18||llyr==45)) ||
+           (layers==3 && (llyr==2||llyr==18||llyr==45));
+  }), tracks.end());
 }
 
 

--- a/mkFit/MkStdSeqs.cc
+++ b/mkFit/MkStdSeqs.cc
@@ -479,6 +479,32 @@ void quality_filter(TrackVec & tracks, const int nMinHits)
   }
 }
 
+void quality_filter_layers(TrackVec & tracks)
+{
+    const auto ntracks = tracks.size();
+ 
+    std::vector<bool> goodtrack(ntracks, true);
+ 
+    for (auto itrack = 0U; itrack < ntracks; itrack++)
+    {
+ 
+      auto &trk = tracks[itrack];
+      auto layers = trk.nUniqueLayers();
+      auto llyr   = trk.getLastFoundHitLyr();
+      auto nhits  = trk.nFoundHits();
+ 
+      if(nhits==3 && (llyr==2||llyr==18||llyr==45)) goodtrack[itrack]=false;
+      if(layers==3 && (llyr==2||llyr==18||llyr==45)) goodtrack[itrack]=false;
+      //if (layers >= nLayers) goodtrack[itrack]=true;
+ 
+    }
+    for (int itrack = ntracks-1; itrack >-1; itrack--)
+    {
+      if(!goodtrack[itrack]) tracks.erase(tracks.begin() + itrack);
+    }
+}
+
+
 void find_duplicates_sharedhits(TrackVec &tracks, const float fraction)
 {
   const auto ntracks = tracks.size();
@@ -640,6 +666,7 @@ void find_and_remove_duplicates(TrackVec &tracks, const IterationConfig &itconf)
   }
   else if(itconf.m_require_dupclean_tight) 
   {
+    if(itconf.m_track_algorithm==7) quality_filter_layers(tracks);
     find_duplicates_sharedhits_pixelseed(tracks, itconf.m_params.fracSharedHits, itconf.m_params.drth_central, itconf.m_params.drth_obarrel, itconf.m_params.drth_forward);
   }
   else

--- a/mkFit/MkStdSeqs.h
+++ b/mkFit/MkStdSeqs.h
@@ -35,6 +35,8 @@ namespace StdSeq
     void find_duplicates_sharedhits(TrackVec &tracks, const float fraction);
     void find_duplicates_sharedhits_pixelseed(TrackVec &tracks, const float fraction, const float drth_central, const float drth_obarrel, const float drth_forward);
 
+    void quality_filter_layers(TrackVec &tracks);
+
     template<class TRACK>
     bool qfilter_n_hits(const TRACK &t, int nMinHits)
     {


### PR DESCRIPTION
Retuned detached triplet - supersedes 337

- added quality filter for fakes
- looser duplicate removal on top

the PR is a bit hardcoded and was only compiled in this round (tested extensively in MTV earlier). I am making the PR to converge before testing the seed region rebuild for this iteration and will provide more validation plots and improved code later.