### PR TITLE
Stop candidates before they reach apogee.

### DIFF
--- a/Track.h
+++ b/Track.h
@@ -89,6 +89,7 @@ public:
   float y()      const {return parameters.At(1);}
   float z()      const {return parameters.At(2);}
   float posR()   const {return getHypot(x(),y());}
+  float posRsq() const {return x()*x() + y()*y();}
   float posPhi() const {return getPhi  (x(),y());}
   float posEta() const {return getEta  (posR(),z());}
 
@@ -180,6 +181,7 @@ public:
   float y()      const { return state_.parameters[1]; }
   float z()      const { return state_.parameters[2]; }
   float posR()   const { return getHypot(state_.parameters[0],state_.parameters[1]); }
+  float posRsq() const { return state_.posRsq(); }
   float posPhi() const { return getPhi(state_.parameters[0],state_.parameters[1]); }
   float posEta() const { return getEta(state_.parameters[0],state_.parameters[1],state_.parameters[2]); }
 

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -1488,6 +1488,15 @@ int MkBuilder::find_tracks_unroll_candidates(std::vector<std::pair<int,int>> & s
       {
         if (ccand[ic].getLastHitIdx() != -2)
         {
+         // Check if the candidate is close to it's max_r, pi/2 - 0.2 rad (11.5 deg)
+         const float dphi = std::abs(ccand[ic].posPhi() - ccand[ic].momPhi());
+         if (ccand[ic].posRsq() > 625.f && dphi > 1.371f && dphi < 4.512f)
+         {
+          // printf("Stopping cand at r=%f, posPhi=%.1f momPhi=%.2f pt=%.2f emomEta=%.2f\n",
+          //        ccand[ic].posR(), ccand[ic].posPhi(), ccand[ic].momPhi(), ccand[ic].pT(), ccand[ic].momEta());
+         }
+         else
+         {
           active = true;
           seed_cand_vec.push_back(std::pair<int,int>(iseed,ic));
           ccand.m_overlap_hits[ic].reset();
@@ -1499,6 +1508,7 @@ int MkBuilder::find_tracks_unroll_candidates(std::vector<std::pair<int,int>> & s
                                          "Per layer silly check"))
               ++silly_count;
           }
+         }
         }
       }
       if ( ! active)

--- a/mkFit/MkBuilder.h
+++ b/mkFit/MkBuilder.h
@@ -199,7 +199,8 @@ public:
 
   int  find_tracks_unroll_candidates(std::vector<std::pair<int,int>> & seed_cand_vec,
                                      int start_seed, int end_seed,
-                                     int prev_layer, bool pickup_only);
+                                     int layer, int prev_layer, bool pickup_only,
+                                     SteeringParams::IterationType_e iteration_dir);
 
   void find_tracks_handle_missed_layers(MkFinder *mkfndr, const LayerInfo &layer_info,
                                         std::vector<std::vector<TrackCand>> &tmp_cands,


### PR DESCRIPTION
Stops tracks when their dr/ds angle gets shallower than 0.2 rad (11.5 deg).
Radius below which the stopping is not applied is 25cm. 
There is no pT cut, it does not seem to be needed, but could save us some atan2s if we apply it and the r_min cut first.

I don't know if tuning of dr/ds cut makes sense.

I suspect this will partially overlap with large-cluster cut in #358, esp. in barrel

MTV vs CKF and #355 (devel): http://xrd-cache-1.t2.ucsd.edu/matevz/PKF/stop-loopers
MTV with #355 as ref:  http://xrd-cache-1.t2.ucsd.edu/matevz/PKF/stop-loopers.vs.355
```
sample=ttbarpu50
maxEvents=1000
mkfit="InitialStepPreSplitting,InitialStep,HighPtTripletStep,DetachedQuadStep,DetachedTripletStep,PixelLessStep,TobTecStep"
```