### PR TITLE
reapply strip cluster charge cut (loose) using track impact angle

### DIFF
--- a/Hit.h
+++ b/Hit.h
@@ -278,6 +278,7 @@ public:
   unsigned int spanRows()     const { return pdata_.span_rows + 1; }
   unsigned int spanCols()     const { return pdata_.span_cols + 1; }
 
+  static unsigned int minChargePerCM() { return 1620; }
   static unsigned int maxChargePerCM() { return 1620 + (0xfe << 3); }
   static unsigned int maxSpan()        { return 8; }
 

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -864,11 +864,11 @@ bool passStripChargePCMfromTrack(int itrack, bool isBarrel, unsigned int pcm, un
     const float cosP = cos(pPar.ConstAt(itrack,4,0));
     const float sinP = sin(pPar.ConstAt(itrack,4,0));
     const float sinT = std::abs(sin(pPar.ConstAt(itrack,5,0)));
-    //qSF = (px,py)*(1-proj)*(px,py)/p = sinT*sqrt[(cosP,sinP)*(1-proj)*(cosP,sinP)].
+    //qSF = sqrt[(px,py)*(1-proj)*(px,py)]/p = sinT*sqrt[(cosP,sinP)*(1-proj)*(cosP,sinP)].
     qSF = detXY_OK ? sinT*std::sqrt(std::abs(1.f + cosP*cosP*proj[0] + sinP*sinP*proj[2] - 2.f*cosP*sinP*proj[1]) )
                    : 1.f;
   } else {//project on z
-    // p_zLocal = p_z/p = cosT
+    // p_zLocal/p = p_z/p = cosT
     qSF = std::abs(cos(pPar.ConstAt(itrack,5,0)));
   }
 


### PR DESCRIPTION
- the strip cluster charge is expected to scale proportionally to the track path in the module
- the raw `pcm = charge/L_normal` is applied upstream in CMSSW gives the loosest possible cut cluster charge
- this PR computes a corrected `qCorr = charge/L_path = charge/(L_normal*p/p_zLocal) = pcm*p_zLocal/p`, where the zLocal direction is orthogonal to the module plane
    - hits with `pcm` at or above the overflow value 3652 ("only" 2.2 times the cut value) are not corrected
    - in the barrel it is assumed/approximated to be in the (x,y) plane and the `p_zLocal` projection is made using the hit error matrix component in the (x,y) plane. The math is expressed in vector terms without explicit eigenvector computation. Here a diagonalized version is expected to be `diag(sigma_strip^2, 0)`, or `proj = msErr/trace(msErr)` after diagonalization to be `diag(1, 0)` within numerical precision. About 1% of the hits is not corrected if they have `det(proj)> 0.1`, which would mean that the module normal is partly along the global z direction due to misalignment. For the remaining majority of the hits `qSF = p_zLocal/p = sqrt[(px,py)*(1-proj)*(px,py)]/p = sqrt[(cosP,sinP)*(1-proj)*(cosP,sinP)]`
    - in the endcap the zLocal is simply assumed to be the global z direction

The reason to apply this cut was motivated by the tracker DQM plots https://tinyurl.com/yg3qvray  
<img width="500" alt="image" src="https://user-images.githubusercontent.com/4676718/134771044-7f4384a7-c8f3-4dfb-8953-1a6f6120b45e.png">
here in mkFit we start from the cut at 1620 on `pcm` and the plot is made for relatively straight tracks (`p>2 && pt>0.8`), so after the correction to the origin the hits can extend to 1620/[cosh(η_max for TIB1 = 1.7) = 2.8] ≈ 600`, in pretty good agreement with the plot.

Validation
- mtv-7iter http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/ttbar50_CKF_mkFit-7-pr357_PCMfromTrack_mffe5c6e_c9266151/
- 4-iter http://uaf-10.t2.ucsd.edu/~slava77/figs/mic/mtv/ttbar50_CKF_mkFit-4-pr357_PCMfromTrack_mffe5c6e_c9266151/

In the 7iter initial step built tracks:
the fakerate at low pt is down by about 5% relative with a small increase in efficiency
<img width="938" alt="image" src="https://user-images.githubusercontent.com/4676718/134771233-e288b8be-9246-442a-ae9e-1a1bbf7598e1.png">
<img width="936" alt="image" src="https://user-images.githubusercontent.com/4676718/134771915-5e54c395-05c9-49af-a5e0-32b14f249ebc.png">
only strip hits count changes (pixels are unchanged, as expected) and mostly in the η range from 1 to 1.7 where the angle wrt module normal is the largest
<img width="879" alt="image" src="https://user-images.githubusercontent.com/4676718/134771259-dc577a34-a390-488e-8fde-87647a993d2f.png">

all tracks:
<img width="888" alt="image" src="https://user-images.githubusercontent.com/4676718/134771847-7b4d82e5-20a1-4d57-a081-7545a240af8c.png">

The CPU cost seems to be small: https://github.com/trackreco/mkFit/pull/361#issuecomment-927323163 suggests that the increase if any is below 1% of the building time

After this PR:
- on a longer term, perhaps compare to a correction assuming straight line from origin, using the hit position; this should save quite a bit of CPU cost by avoiding 3 sin/cos computations
- consider a configurable cut per iteration (some iters have a tight cut at 1945 (instead of a loose value at 1620)); this would allow a tighter cut in some places, compared to this hardcoded baseline

Things to check before merging
- check if the tracker DQM confirms that the updated charge distributions now agree with CKF (@mmasciov do you have a setup for this?)
