### PR TITLE
update bin files  fv6.default.211008-c6b7c67.bin to include beamSpot information

### DIFF
--- a/val_scripts/validation-cmssw-10mu-fulldet-build-extrectracks.sh
+++ b/val_scripts/validation-cmssw-10mu-fulldet-build-extrectracks.sh
@@ -4,7 +4,7 @@ make -j 32 WITH_ROOT:=1
 
 dir=/data2/slava77/samples/2021/
 subdir=10muPt0p2to10HS/
-file=memoryFile.fv5.default.210729-d1dc487.bin
+file=memoryFile.fv6.default.211008-c6b7c67.bin
 fin10mu=${dir}/${subdir}/${file}
 
 base=SNB_CMSSW_10mu

--- a/val_scripts/validation-cmssw-10mu-fulldet-build.sh
+++ b/val_scripts/validation-cmssw-10mu-fulldet-build.sh
@@ -4,7 +4,7 @@ make -j 32 WITH_ROOT:=1
 
 dir=/data2/slava77/samples/2021/
 subdir=10muPt0p2to10HS/
-file=memoryFile.fv5.default.210729-d1dc487.bin
+file=memoryFile.fv6.default.211008-c6b7c67.bin
 fin10mu=${dir}/${subdir}/${file}
 
 base=SKL-SP_CMSSW_10mu

--- a/val_scripts/validation-cmssw-benchmarks-multiiter.sh
+++ b/val_scripts/validation-cmssw-benchmarks-multiiter.sh
@@ -30,13 +30,13 @@ case ${inputBin} in
         echo "Inputs from 2021 TTbar (PU50) sample with multiple iterations and hit binary mask"
         dir=/data2/slava77/samples/
         subdir=2021/11834.0_TTbar_14TeV+2021/AVE_50_BX01_25ns/
-        file=memoryFile.fv5.default.210729-d1dc487.bin
+        file=memoryFile.fv6.default.211008-c6b7c67.bin
         ;;
 "112X_10mu_MULTI")
         echo "Inputs from 2021 10mu sample with multiple iterations and hit binary mask"
         dir=/data2/slava77/samples
         subdir=2021/10muPt0p2to1000HS
-        file=memoryFile.fv5.default.210729-d1dc487.bin
+        file=memoryFile.fv6.default.211008-c6b7c67.bin
         nevents=20000
         sample=10mu
         ;;

--- a/val_scripts/validation-cmssw-benchmarks.sh
+++ b/val_scripts/validation-cmssw-benchmarks.sh
@@ -36,7 +36,7 @@ case ${inputBin} in
         echo "Inputs from 2021 TTbar (PU50) sample with multiple iterations and hit binary mask"
         dir=/data2/slava77/samples/
         subdir=2021/11834.0_TTbar_14TeV+2021/AVE_50_BX01_25ns/
-        file=memoryFile.fv5.default.210729-d1dc487.bin
+        file=memoryFile.fv6.default.211008-c6b7c67.bin
         ;;
 "104X10muCCC")
         echo "Inputs from 2018 10mu large pt range using the offline initialStep seeds with CCC (phi3)"
@@ -50,7 +50,7 @@ case ${inputBin} in
         echo "Inputs from 2021 10mu sample with multiple iterations and hit binary mask"
         dir=/data2/slava77/samples
         subdir=2021/10muPt0p2to1000HS
-        file=memoryFile.fv5.default.210729-d1dc487.bin
+        file=memoryFile.fv6.default.211008-c6b7c67.bin
         nevents=20000
         sample=10mu
         ;;

--- a/val_scripts/validation-cmssw-ttbar-fulldet-build-extrectracks.sh
+++ b/val_scripts/validation-cmssw-ttbar-fulldet-build-extrectracks.sh
@@ -3,7 +3,7 @@
 make -j 32 WITH_ROOT:=1
 
 dir=/data2/slava77/samples/2021/11834.0_TTbar_14TeV+2021/
-file=memoryFile.fv5.default.210729-d1dc487.bin
+file=memoryFile.fv6.default.211008-c6b7c67.bin
 
 NoPU=AVE_0_BX01_25ns/
 PU35=AVE_35_BX01_25ns/

--- a/val_scripts/validation-cmssw-ttbar-fulldet-build.sh
+++ b/val_scripts/validation-cmssw-ttbar-fulldet-build.sh
@@ -3,7 +3,7 @@
 make -j 32 WITH_ROOT:=1
 
 dir=/data2/slava77/samples/2021/11834.0_TTbar_14TeV+2021/
-file=memoryFile.fv5.default.210729-d1dc487.bin
+file=memoryFile.fv6.default.211008-c6b7c67.bin
 
 NoPU=AVE_0_BX01_25ns/
 PU35=AVE_35_BX01_25ns/

--- a/val_scripts/validationMIC-build-10mu.sh
+++ b/val_scripts/validationMIC-build-10mu.sh
@@ -2,7 +2,7 @@
 
 
 [ -e "$BIN_DATA_PATH" ] || BIN_DATA_PATH=/data2/slava77/samples/2021/
-fin10mu=${BIN_DATA_PATH}/10muPt0p2to10HS/memoryFile.fv5.default.210729-d1dc487.bin
+fin10mu=${BIN_DATA_PATH}/10muPt0p2to10HS/memoryFile.fv6.default.211008-c6b7c67.bin
 
 runValidation(){
     for sV in "sim --cmssw-simseeds" "see --cmssw-stdseeds"; do echo $sV | while read -r sN sO; do

--- a/val_scripts/validationMIC-build-PU70.sh
+++ b/val_scripts/validationMIC-build-PU70.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 [ -e "$BIN_DATA_PATH" ] || BIN_DATA_PATH=/data2/slava77/samples/2021/11834.0_TTbar_14TeV+2021/
-fin=${BIN_DATA_PATH}/AVE_70_BX01_25ns/memoryFile.fv5.default.210729-d1dc487.bin
+fin=${BIN_DATA_PATH}/AVE_70_BX01_25ns/memoryFile.fv6.default.211008-c6b7c67.bin
 
 runValidation()
 {

--- a/xeon_scripts/benchmark-cmssw-ttbar-fulldet-build.sh
+++ b/xeon_scripts/benchmark-cmssw-ttbar-fulldet-build.sh
@@ -66,7 +66,7 @@ fi
 ## Common file setup
 dir=/data2/slava77/samples/
 subdir=2021/11834.0_TTbar_14TeV+2021/AVE_50_BX01_25ns/
-file=memoryFile.fv5.default.210729-d1dc487.bin
+file=memoryFile.fv6.default.211008-c6b7c67.bin
 nevents=20
 
 ## Common executable setup

--- a/xeon_scripts/benchmarkMIC-build.sh
+++ b/xeon_scripts/benchmarkMIC-build.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 [ -e "$BIN_DATA_PATH" ] || BIN_DATA_PATH=/data2/slava77/samples/2021/11834.0_TTbar_14TeV+2021/
-fin=${BIN_DATA_PATH}/AVE_70_BX01_25ns/memoryFile.fv5.default.210729-d1dc487.bin
+fin=${BIN_DATA_PATH}/AVE_70_BX01_25ns/memoryFile.fv6.default.211008-c6b7c67.bin
 
 runBenchmark()
 {
@@ -49,7 +49,7 @@ runBenchmark 1
 make clean
 make distclean
 
-fin10mu=/data2/slava77/samples/2021/10muPt0p2to10HS/memoryFile.fv5.default.210729-d1dc487.bin 
+fin10mu=/data2/slava77/samples/2021/10muPt0p2to10HS/memoryFile.fv6.default.211008-c6b7c67.bin
 
 runBenchmark10mu()
 {

--- a/xeon_scripts/debug-test.sh
+++ b/xeon_scripts/debug-test.sh
@@ -10,7 +10,7 @@ source xeon_scripts/init-env.sh
 ## Common setup
 dir=/data2/slava77/samples/2021/
 subdir=10muPt0p2to10HS
-file=memoryFile.fv5.default.210729-d1dc487.bin
+file=memoryFile.fv6.default.211008-c6b7c67.bin
 
 ## config for debug
 nevents=10

--- a/xeon_scripts/stress-test-main.sh
+++ b/xeon_scripts/stress-test-main.sh
@@ -70,7 +70,7 @@ fi
 ## Common file setup
 dir=/data2/slava77/samples/
 subdir=2021/11834.0_TTbar_14TeV+2021/AVE_50_BX01_25ns/
-file=memoryFile.fv5.default.210729-d1dc487.bin
+file=memoryFile.fv6.default.211008-c6b7c67.bin
 
 ## Common mkFit options
 seeds="--cmssw-n2seeds"

--- a/xeon_scripts/throughput-test-main.sh
+++ b/xeon_scripts/throughput-test-main.sh
@@ -38,7 +38,7 @@ fi
 ## Common file setup
 dir=/data2/slava77/samples/
 subdir=2021/11834.0_TTbar_14TeV+2021/AVE_50_BX01_25ns/
-file=memoryFile.fv5.default.210729-d1dc487.bin
+file=memoryFile.fv6.default.211008-c6b7c67.bin
 #base_nevents=20 # 7/2 seconds
 base_nevents=2000 # 30/10 minutes
 


### PR DESCRIPTION
This is a catch-up PR for #364 

from from fv5.default.210729-d1dc487.bin (full stats)
to fv6.default.211008-c6b7c67.bin (limited stats: 1K ttbar; 10K evt particle guns).


I did not run standalone validation on these: 
- the new feature ( beamSpot) will be used only in #365 
- I expect that the simple reduction in stats should be manageable at this stage (except for some older full node long throughput tests, we never used so many events)

