### PR TITLE
Adding counting of layers with match to TrackCand

### DIFF
--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -513,6 +513,7 @@ public:
   int        nUniqueLayers()      const;
 
   int        nUniqueLayersMatch(const TrackerInfo &trk_inf) const;
+  int        nLayersByType(const TrackerInfo &trk_inf) const;
 
   void  addHitIdx(int hitIdx, int hitLyr, float chi2);
 
@@ -812,6 +813,29 @@ inline int TrackCand::nUniqueLayersMatch(const TrackerInfo &trk_inf) const
   return nULM;
 }
 
+inline int TrackCand::nLayersByType(const TrackerInfo &trk_inf) const
+{
+  int prevL = -1;
+  int nh = nTotalHits();
+  int ch = lastHitIdx_;
+  int pix=0, stereo=0, mono=0;
+  while (--nh >= 0)
+  {
+    HoTNode& hot_node = m_comb_candidate->m_hots[ch];
+    int thisL = hot_node.m_hot.layer;
+    if (thisL >=0 && (hot_node.m_hot.index >= 0 || hot_node.m_hot.index == -9) && thisL != prevL)
+    {
+      if (trk_inf.is_pix_lyr(thisL)) ++pix;
+      else if (trk_inf.is_stereo_lyr(thisL) ) ++stereo;
+      else ++mono;
+      prevL = thisL;
+     }
+    ch = hot_node.m_prev_idx;
+  }
+  return pix+100*stereo+10000*mono;
+}
+
+
 inline HoTNode& TrackCand::refLastHoTNode()
 {
   return m_comb_candidate->m_hots[lastHitIdx_];
@@ -821,7 +845,6 @@ inline const HoTNode& TrackCand::refLastHoTNode() const
 {
   return m_comb_candidate->m_hots[lastHitIdx_];
 }
-
 
 //------------------------------------------------------------------------------
 

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -839,7 +839,6 @@ inline int TrackCand::nLayersByTypeEncoded(const TrackerInfo &trk_inf) const
     int thisL = hot_node.m_hot.layer;
     if (thisL >=0 && (hot_node.m_hot.index >= 0 || hot_node.m_hot.index == -9) && thisL != prevL)
     {
-      std::cout << "thisL " << thisL <<" p "<< trk_inf.is_pix_lyr(thisL) <<" s "<< trk_inf.is_stereo_lyr(thisL) << std::endl;
       if (trk_inf.is_pix_lyr(thisL)) ++pix;
       else if (trk_inf.is_stereo_lyr(thisL) ) ++stereo;
       else 

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -512,6 +512,8 @@ public:
   int        getLastFoundHitLyr() const;
   int        nUniqueLayers()      const;
 
+  int        nUniqueLayersMatch(const TrackerInfo &trk_inf) const;
+
   void  addHitIdx(int hitIdx, int hitLyr, float chi2);
 
         HoTNode& refLastHoTNode();       // for filling up overlap info
@@ -780,6 +782,34 @@ inline int TrackCand::nUniqueLayers() const
     ch = hot_node.m_prev_idx;
   }
   return nUL;
+}
+
+inline int TrackCand::nUniqueLayersMatch(const TrackerInfo &trk_inf) const
+{
+  int nULM   = 0;
+  int prevL = -1;
+  bool prevStereo = false;
+  int nh = nTotalHits();
+  int ch = lastHitIdx_;
+
+  while (--nh >= 0)
+  {
+    HoTNode& hot_node = m_comb_candidate->m_hots[ch];
+    int thisL = hot_node.m_hot.layer;
+    bool stereo = trk_inf.is_stereo_lyr(thisL);
+
+    if (thisL >=0 && (hot_node.m_hot.index >= 0 || hot_node.m_hot.index == -9) && thisL != prevL)
+    {
+      ++nULM;
+      //going outside in you can find a mono-stereo layer pair
+      //if they both have valid hits count once
+      if (!stereo && prevStereo && thisL==prevL-1) nULM--;
+      prevL = thisL;
+      prevStereo = stereo;
+    }
+    ch = hot_node.m_prev_idx;
+  }
+  return nULM;
 }
 
 inline HoTNode& TrackCand::refLastHoTNode()


### PR DESCRIPTION
Adding a function to track cand that counts once the layers if they are a mono+stereo pair and they both have a valid hit 

Example of matching and counting reduction in the figure going from 5 to 3 layers. the hits are counte inwards and the stereo layer is the outer one

![image](https://user-images.githubusercontent.com/7805577/138158091-a68aab9c-be63-4606-b9d6-b3e3e83476b8.png)

this counter should be tested in filters that we already are using