### PR TITLE
Add filter to remove nan and silly candidates

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -397,8 +397,8 @@ namespace Config
 
   constexpr bool nan_n_silly_check_seeds      = true;
   constexpr bool nan_n_silly_print_bad_seeds  = false;
-  constexpr bool nan_n_silly_fixup_bad_seeds  = true;
-  constexpr bool nan_n_silly_remove_bad_seeds = false;
+  constexpr bool nan_n_silly_fixup_bad_seeds  = false;
+  constexpr bool nan_n_silly_remove_bad_seeds = true;
 
   constexpr bool nan_n_silly_check_cands_every_layer     = false;
   constexpr bool nan_n_silly_print_bad_cands_every_layer = false;

--- a/Track.cc
+++ b/Track.cc
@@ -183,11 +183,8 @@ bool TrackBase::hasNanNSillyValues() const
     {
       if ((i == j && state_.errors.At(i,j) < 0) || ! std::isfinite(state_.errors.At(i,j)))
       {
-        if ( ! is_silly )
-        {
-          is_silly = true;
-	  break;
-        }
+	is_silly = true;
+	return is_silly;
       }
     }
   }

--- a/Track.cc
+++ b/Track.cc
@@ -160,7 +160,7 @@ bool TrackBase::hasSillyValues(bool dump, bool fix, const char* pref)
     {
       if ((i == j && state_.errors.At(i,j) < 0) || ! std::isfinite(state_.errors.At(i,j)))
       {
-        if ( ! is_silly)
+        if ( ! is_silly )
         {
           is_silly = true;
           if (dump) printf("%s (label=%d, pT=%f):", pref, label(), pT());

--- a/Track.cc
+++ b/Track.cc
@@ -174,6 +174,26 @@ bool TrackBase::hasSillyValues(bool dump, bool fix, const char* pref)
   return is_silly;
 }
 
+bool TrackBase::hasNanNSillyValues() const
+{
+  bool is_silly = false;
+  for (int i = 0; i < LL; ++i)
+  {
+    for (int j = 0; j <= i; ++j)
+    {
+      if ((i == j && state_.errors.At(i,j) < 0) || ! std::isfinite(state_.errors.At(i,j)))
+      {
+        if ( ! is_silly )
+        {
+          is_silly = true;
+	  break;
+        }
+      }
+    }
+  }
+  return is_silly;
+}
+
 // If linearize=true, use linear estimate of d0: suitable at pT>~10 GeV (--> 10 micron error)
 float TrackBase::d0BeamSpot(const float x_bs, const float y_bs, bool linearize) const
 {

--- a/Track.h
+++ b/Track.h
@@ -214,6 +214,8 @@ public:
 
   bool  hasSillyValues(bool dump, bool fix, const char* pref="");
 
+  bool  hasNanNSillyValues() const;
+
   float d0BeamSpot(const float x_bs, const float y_bs, bool linearize=false) const;
 
   // ------------------------------------------------------------------------

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -1113,7 +1113,7 @@ void MkBuilder::score_tracks(TrackVec& tracks)
 // PrepareSeeds
 //------------------------------------------------------------------------------
 
-void MkBuilder::seed_post_cleaning(TrackVec &tv, const bool fix_silly_seeds, const bool remove_silly_seeds)
+void MkBuilder::seed_post_cleaning(TrackVec &tv)
 {
 #ifdef SELECT_SEED_LABEL
   { // Select seed with the defined label for detailed debugging.
@@ -1190,7 +1190,7 @@ void MkBuilder::PrepareSeeds()
     }
     // create_seeds_from_sim_tracks();
 
-    seed_post_cleaning(m_event->seedTracks_, true, true);
+    seed_post_cleaning(m_event->seedTracks_);
   }
   else if (Config::seedInput == cmsswSeeds)
   {
@@ -1245,7 +1245,7 @@ void MkBuilder::PrepareSeeds()
       exit(1);
     }
 
-    seed_post_cleaning(m_event->seedTracks_, true, true);
+    seed_post_cleaning(m_event->seedTracks_);
 
     // in rare corner cases, seed tracks could be fully cleaned out: skip mapping if so
     if (m_event->seedTracks_.empty()) return;

--- a/mkFit/MkBuilder.h
+++ b/mkFit/MkBuilder.h
@@ -219,7 +219,7 @@ public:
                              const int start_seed, const int end_seed, const int region);
 
   // --------
-  static void seed_post_cleaning(TrackVec &tv, const bool fix_silly_seeds, const bool remove_silly_seeds);
+  static void seed_post_cleaning(TrackVec &tv);
 
   void PrepareSeeds();
 

--- a/mkFit/MkStdSeqs.h
+++ b/mkFit/MkStdSeqs.h
@@ -78,6 +78,12 @@ namespace StdSeq
       return !( (nhits<=6 || layers<=6) && std::abs(d0BS)>d0_max );
     }
 
+    template<class TRACK>
+    bool qfilter_nan_n_silly(const TRACK &t)
+    {
+      return !( t.hasNanNSillyValues() );
+    }
+
     void find_and_remove_duplicates(TrackVec &tracks, const IterationConfig &itconf);
 
 } // namespace StdSeq

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -490,7 +490,7 @@ std::vector<double> runBtpCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuil
     if ( itconf.m_requires_dupclean_tight )
       StdSeq::clean_cms_seedtracks_iter(&seeds, itconf);
 
-    builder.seed_post_cleaning(seeds, true, true);
+    builder.seed_post_cleaning(seeds);
 
     // Add protection in case no seeds are found for iteration
     if (seeds.size() <= 0)
@@ -655,7 +655,7 @@ void run_OneIteration(const TrackerInfo& trackerInfo, const IterationConfig &itc
 
   // Check nans in seeds -- this should not be needed when Slava fixes
   // the track parameter coordinate transformation.
-  builder.seed_post_cleaning(seeds, true, true);
+  builder.seed_post_cleaning(seeds);
 
   if (itconf.m_requires_seed_hit_sorting)
   {

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -84,7 +84,7 @@ namespace
     return count;
   }
 
-  void check_nan_n_silly_candiates(Event &ev)
+  void check_nan_n_silly_candidates(Event &ev)
   {
     // MIMI -- nan_n_silly_per_layer_count is in MkBuilder, could be in MkJob.
     // if (Config::nan_n_silly_check_cands_every_layer)
@@ -280,7 +280,7 @@ double runBuildingTestPlexStandard(Event& ev, const EventOfHits &eoh, MkBuilder&
   __SSC_MARK(0x222);  // use this to pause Intel SDE at the same point
 #endif
 
-  check_nan_n_silly_candiates(ev);
+  check_nan_n_silly_candidates(ev);
 
   // first store candidate tracks
   builder.quality_store_tracks(ev.candidateTracks_);
@@ -370,7 +370,7 @@ double runBuildingTestPlexCloneEngine(Event& ev, const EventOfHits &eoh, MkBuild
   __SSC_MARK(0x222);  // use this to pause Intel SDE at the same point
 #endif
 
-  check_nan_n_silly_candiates(ev);
+  check_nan_n_silly_candidates(ev);
 
   // first store candidate tracks - needed for BH backward fit and root_validation
   builder.quality_store_tracks(ev.candidateTracks_);
@@ -572,6 +572,9 @@ std::vector<double> runBtpCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuil
 	}
       }
 
+      builder.filter_comb_cands([&](const TrackCand &t)
+       { return StdSeq::qfilter_nan_n_silly(t); });
+
       builder.select_best_comb_cands(true); // true -> clear m_tracks as they were already filled once above
 
       StdSeq::find_and_remove_duplicates(builder.ref_tracks_nc(), itconf);
@@ -592,7 +595,7 @@ std::vector<double> runBtpCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuil
       ev.seedTracks_.swap(seeds_used);
   }    
 
-  check_nan_n_silly_candiates(ev);
+  check_nan_n_silly_candidates(ev);
 
   if (Config::backwardFit) check_nan_n_silly_bkfit(ev);
 
@@ -708,6 +711,9 @@ void run_OneIteration(const TrackerInfo& trackerInfo, const IterationConfig &itc
       }
     }
   }
+
+  builder.filter_comb_cands([&](const TrackCand &t)
+   { return StdSeq::qfilter_nan_n_silly(t); });
 
   builder.export_best_comb_cands(out_tracks);
 


### PR DESCRIPTION
### PR description
This PR introduces a filter on 'silly' candidates, to avoid error/warning messages in CMSSW, addressing #373.

### PR validation
Physics performance is unchanged.
Timing performance is also ~ unchanged (in the plots linked below there is an offset in the measurement; however, after subtracting such offset, timing is indeed unchanged).
MTV results based on TTbar (<PU>=50): http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/MTV_testNanNSillyRemoval/
Running on 100 events, the size of the log file decreases from 3.6 MB to 1.3 MB 
(note that the warning suppression introduced by Slava in cms-sw/cmssw#35802 is not included).
The instances of 'candidate ignored' decrease from 4778 to 53.
