### PR TITLE
Introduce criterion for seed cleaning, based on d0(BS)

### DIFF
--- a/mkFit/MkStdSeqs.cc
+++ b/mkFit/MkStdSeqs.cc
@@ -171,6 +171,7 @@ int clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg,
   std::vector<float>  y(ns);
   std::vector<float>  z(ns);
   std::vector<float>  d0(ns);
+  int i1,i2; //for the sorting
 
   for(int ts=0; ts<ns; ts++){
     const Track & tk = seeds[ts];
@@ -273,13 +274,15 @@ int clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg,
 
       if(overlapping){
         //Mark tss as a duplicate
-        int i1=ts;
-        int i2=tss;
-        //if (d0[tss]>d0[ts])
-        writetrack[tss] = false;
-        //else
-          //   {writetrack[ts] = false;i2=ts;i1=tss;}
-        
+        i1=ts;
+        i2=tss;
+        if (d0[tss]>d0[ts])
+          writetrack[tss] = false;
+        else { 
+          writetrack[ts] = false;
+          i2 = ts;
+          i1 = tss;
+        }
         // Add hits from tk2 to the seed we are keeping.
         // NOTE: We only have 3 bits in Track::Status for number of seed hits.
         //       There is a check at entry and after adding of a new hit.
@@ -313,14 +316,15 @@ int clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg,
             }
           }
         }
+        if (n_ovlp_hits_added > 0)
+           tk.sortHitsByLayer();
       }
-
     } //end of inner loop over tss
 
     if (writetrack[ts])
     {
-      if (n_ovlp_hits_added > 0)
-        seeds[ts].sortHitsByLayer();
+      //if (n_ovlp_hits_added > 0)
+        //seeds[ts].sortHitsByLayer();
       cleanSeedTracks.emplace_back(seeds[ts]);
     }
   }

--- a/mkFit/MkStdSeqs.cc
+++ b/mkFit/MkStdSeqs.cc
@@ -110,7 +110,7 @@ void Cmssw_ReMap_TrackHitIndices(const EventOfHits &eoh, TrackVec &out_tracks)
 //=========================================================================
 // Seed cleaning (multi-iter)
 //=========================================================================
-int clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg)
+int clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg, const BeamSpot &bspot)
 { 
   const float etamax_brl = Config::c_etamax_brl;
   const float dpt_brl_0  = Config::c_dpt_brl_0;
@@ -170,6 +170,7 @@ int clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg)
   std::vector<float>  x(ns);
   std::vector<float>  y(ns);
   std::vector<float>  z(ns);
+  std::vector<float>  d0(ns);
 
   for(int ts=0; ts<ns; ts++){
     const Track & tk = seeds[ts];
@@ -184,6 +185,7 @@ int clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg)
     x[ts] = tk.x();
     y[ts] = tk.y();
     z[ts] = tk.z();
+    d0[ts] = tk.d0BeamSpot(bspot.x,bspot.y);
   }
 
   for(int ts=0; ts<ns; ts++){
@@ -271,15 +273,20 @@ int clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg)
 
       if(overlapping){
         //Mark tss as a duplicate
+        int i1=ts;
+        int i2=tss;
+        //if (d0[tss]>d0[ts])
         writetrack[tss] = false;
-
+        //else
+          //   {writetrack[ts] = false;i2=ts;i1=tss;}
+        
         // Add hits from tk2 to the seed we are keeping.
         // NOTE: We only have 3 bits in Track::Status for number of seed hits.
         //       There is a check at entry and after adding of a new hit.
-        Track &tk = seeds[ts];
+        Track &tk = seeds[i1];
         if (merge_hits && tk.nTotalHits() < 7)
         {
-          const Track &tk2 = seeds[tss];
+          const Track &tk2 = seeds[i2];
           //We are not actually fitting to the extra hits; use chi2 of 0
           float fakeChi2 = 0.0;
 

--- a/mkFit/MkStdSeqs.h
+++ b/mkFit/MkStdSeqs.h
@@ -25,7 +25,7 @@ namespace StdSeq
     void Cmssw_Map_TrackHitIndices(const EventOfHits &eoh, TrackVec &seeds);
     void Cmssw_ReMap_TrackHitIndices(const EventOfHits &eoh, TrackVec &out_tracks);
 
-    int  clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg);
+    int  clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg, const BeamSpot &bspot);
     
     void find_duplicates(TrackVec &tracks);
     void remove_duplicates(TrackVec &tracks);

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -488,7 +488,7 @@ std::vector<double> runBtpCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuil
     }
 
     if ( itconf.m_requires_dupclean_tight )
-      StdSeq::clean_cms_seedtracks_iter(&seeds, itconf);
+      StdSeq::clean_cms_seedtracks_iter(&seeds, itconf, eoh.m_beam_spot);
 
     builder.seed_post_cleaning(seeds, true, true);
 
@@ -647,7 +647,7 @@ void run_OneIteration(const TrackerInfo& trackerInfo, const IterationConfig &itc
   {
     // Seed cleaning not done on pixelLess / tobTec iters
     if ( itconf.m_requires_dupclean_tight ) 
-      StdSeq::clean_cms_seedtracks_iter(&seeds, itconf);
+      StdSeq::clean_cms_seedtracks_iter(&seeds, itconf, eoh.m_beam_spot);
   }
 
   // Check nans in seeds -- this should not be needed when Slava fixes

--- a/val_scripts/validation-cmssw-benchmarks-multiiter.sh
+++ b/val_scripts/validation-cmssw-benchmarks-multiiter.sh
@@ -69,8 +69,8 @@ siminfo="--try-to-save-sim-info"
 bkfit="--backward-fit"
 
 ## validation options: SIMVAL == sim tracks as reference, CMSSWVAL == cmssw tracks as reference
-SIMVAL="SIMVAL --sim-val ${siminfo} ${bkfit} ${style} --num-iters-cmssw 1"
-SIMVAL_SEED="SIMVALSEED --sim-val ${siminfo} ${bkfit} --mtv-require-seeds --num-iters-cmssw 1"
+SIMVAL="SIMVAL --sim-val ${siminfo} ${bkfit} ${style} --num-iters-cmssw 10"
+SIMVAL_SEED="SIMVALSEED --sim-val ${siminfo} ${bkfit} --mtv-require-seeds --num-iters-cmssw 10"
 
 declare -a vals=(SIMVAL SIMVAL_SEED)
 
@@ -98,13 +98,11 @@ SIMPLOTSEED10="SIMVALSEED iter10 0 10 0"
 SIMPLOT6="SIMVAL iter6 0 6 0"
 SIMPLOTSEED6="SIMVALSEED iter6 0 6 0"
 
-declare -a plots=(SIMPLOT4)
-
-#declare -a plots=(SIMPLOT4 SIMPLOTSEED4 SIMPLOT22 SIMPLOTSEED22 SIMPLOT23 SIMPLOTSEED23 SIMPLOT5 SIMPLOTSEED5 SIMPLOT24 SIMPLOTSEED24 SIMPLOT7 SIMPLOTSEED7 SIMPLOT8 SIMPLOTSEED8 SIMPLOT9 SIMPLOTSEED9 SIMPLOT10 SIMPLOTSEED10 SIMPLOT6 SIMPLOTSEED6)
+declare -a plots=(SIMPLOT4 SIMPLOTSEED4 SIMPLOT22 SIMPLOTSEED22 SIMPLOT23 SIMPLOTSEED23 SIMPLOT5 SIMPLOTSEED5 SIMPLOT24 SIMPLOTSEED24 SIMPLOT7 SIMPLOTSEED7 SIMPLOT8 SIMPLOTSEED8 SIMPLOT9 SIMPLOTSEED9 SIMPLOT10 SIMPLOTSEED10 SIMPLOT6 SIMPLOTSEED6)
 
 ## special cmssw dummy build
-CMSSW="CMSSW cmssw SIMVAL --sim-val-for-cmssw ${siminfo} --read-cmssw-tracks ${style} --num-iters-cmssw 1"
-CMSSW2="CMSSW cmssw SIMVALSEED --sim-val-for-cmssw ${siminfo} --read-cmssw-tracks --mtv-require-seeds --num-iters-cmssw 1"
+CMSSW="CMSSW cmssw SIMVAL --sim-val-for-cmssw ${siminfo} --read-cmssw-tracks ${style} --num-iters-cmssw 10"
+CMSSW2="CMSSW cmssw SIMVALSEED --sim-val-for-cmssw ${siminfo} --read-cmssw-tracks --mtv-require-seeds --num-iters-cmssw 10"
 
 ###############
 ## Functions ##

--- a/val_scripts/validation-cmssw-benchmarks-multiiter.sh
+++ b/val_scripts/validation-cmssw-benchmarks-multiiter.sh
@@ -69,8 +69,8 @@ siminfo="--try-to-save-sim-info"
 bkfit="--backward-fit"
 
 ## validation options: SIMVAL == sim tracks as reference, CMSSWVAL == cmssw tracks as reference
-SIMVAL="SIMVAL --sim-val ${siminfo} ${bkfit} ${style} --num-iters-cmssw 10"
-SIMVAL_SEED="SIMVALSEED --sim-val ${siminfo} ${bkfit} --mtv-require-seeds --num-iters-cmssw 10"
+SIMVAL="SIMVAL --sim-val ${siminfo} ${bkfit} ${style} --num-iters-cmssw 1"
+SIMVAL_SEED="SIMVALSEED --sim-val ${siminfo} ${bkfit} --mtv-require-seeds --num-iters-cmssw 1"
 
 declare -a vals=(SIMVAL SIMVAL_SEED)
 
@@ -98,11 +98,13 @@ SIMPLOTSEED10="SIMVALSEED iter10 0 10 0"
 SIMPLOT6="SIMVAL iter6 0 6 0"
 SIMPLOTSEED6="SIMVALSEED iter6 0 6 0"
 
-declare -a plots=(SIMPLOT4 SIMPLOTSEED4 SIMPLOT22 SIMPLOTSEED22 SIMPLOT23 SIMPLOTSEED23 SIMPLOT5 SIMPLOTSEED5 SIMPLOT24 SIMPLOTSEED24 SIMPLOT7 SIMPLOTSEED7 SIMPLOT8 SIMPLOTSEED8 SIMPLOT9 SIMPLOTSEED9 SIMPLOT10 SIMPLOTSEED10 SIMPLOT6 SIMPLOTSEED6)
+declare -a plots=(SIMPLOT4)
+
+#declare -a plots=(SIMPLOT4 SIMPLOTSEED4 SIMPLOT22 SIMPLOTSEED22 SIMPLOT23 SIMPLOTSEED23 SIMPLOT5 SIMPLOTSEED5 SIMPLOT24 SIMPLOTSEED24 SIMPLOT7 SIMPLOTSEED7 SIMPLOT8 SIMPLOTSEED8 SIMPLOT9 SIMPLOTSEED9 SIMPLOT10 SIMPLOTSEED10 SIMPLOT6 SIMPLOTSEED6)
 
 ## special cmssw dummy build
-CMSSW="CMSSW cmssw SIMVAL --sim-val-for-cmssw ${siminfo} --read-cmssw-tracks ${style} --num-iters-cmssw 10"
-CMSSW2="CMSSW cmssw SIMVALSEED --sim-val-for-cmssw ${siminfo} --read-cmssw-tracks --mtv-require-seeds --num-iters-cmssw 10"
+CMSSW="CMSSW cmssw SIMVAL --sim-val-for-cmssw ${siminfo} --read-cmssw-tracks ${style} --num-iters-cmssw 1"
+CMSSW2="CMSSW cmssw SIMVALSEED --sim-val-for-cmssw ${siminfo} --read-cmssw-tracks --mtv-require-seeds --num-iters-cmssw 1"
 
 ###############
 ## Functions ##


### PR DESCRIPTION
### PR description

As of today, we do not apply any criterion to decide what seed to keep during seed cleaning.
This PR by @leonardogiannini introduces a criterion based on d0(BS), keeping the promptest seed.
As seed cleaning is only applied in pixel-seeded iteration, this appears to be a safe choice.

### PR validation

No significant difference is expected, nor observed:
- QCD Pt1800-2400, no PU: http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/initialStepFilter/MTV_QCD_pr375/
- TTbar with PU: http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/initialStepFilter/MTV_TTbar_pr375/
