### PR TITLE
Do not export missing hits, avoid extra material effect application in backward-fit

### DIFF
--- a/mkFit/HitStructures.cc
+++ b/mkFit/HitStructures.cc
@@ -445,27 +445,33 @@ EventOfHits::EventOfHits(const TrackerInfo &trk_inf) :
 // TrackCand
 //==============================================================================
 
-Track TrackCand::exportTrack() const
+Track TrackCand::exportTrack(bool remove_missing_hits) const
 {
   // printf("TrackCand::exportTrack label=%5d, total_hits=%2d, overlaps=%2d -- n_seed_hits=%d,prod_type=%d\n",
   //        label(), nTotalHits(), nOverlapHits_, getNSeedHits(), (int)prodType());
 
   Track res(*this);
-  res.resizeHits(nTotalHits(), nFoundHits());
+  res.resizeHits(remove_missing_hits ? nFoundHits() : nTotalHits(), nFoundHits());
   res.setNOverlapHits(nOverlapHits());
 
   int nh = nTotalHits();
   int ch = lastHitIdx_;
+  int good_hits_pos = nFoundHits();
   while (--nh >= 0)
   {
     HoTNode& hot_node = m_comb_candidate->m_hots[ch];
-
-    res.setHitIdxAtPos(nh, hot_node.m_hot);
-
+    if (remove_missing_hits)
+    {
+      if (hot_node.m_hot.index >= 0)
+        res.setHitIdxAtPos(--good_hits_pos, hot_node.m_hot);
+    }
+    else
+    {
+      res.setHitIdxAtPos(nh, hot_node.m_hot);
+    }
     // printf("  nh=%2d, ch=%d, idx=%d lyr=%d prev_idx=%d\n",
     //        nh, ch, hot_node.m_hot.index, hot_node.m_hot.layer, hot_node.m_prev_idx);
-
-    ch       = hot_node.m_prev_idx;
+    ch = hot_node.m_prev_idx;
   }
 
   return res;

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -528,7 +528,7 @@ public:
 
   void  incOverlapCount() { ++nOverlapHits_; }
 
-  Track exportTrack() const;
+  Track exportTrack(bool remove_missing_hits=false) const;
 
   void  resetShortTrack() { score_ = getScoreWorstPossible(); m_comb_candidate = nullptr; }
 

--- a/mkFit/MkBase.h
+++ b/mkFit/MkBase.h
@@ -45,7 +45,8 @@ public:
                            Err[iP], Par[iP], N_proc, pf);
   }
 
-  void PropagateTracksToHitR(const MPlexHV& par, const int N_proc, const PropagationFlags pf)
+  void PropagateTracksToHitR(const MPlexHV& par, const int N_proc, const PropagationFlags pf,
+                             const MPlexQI *noMatEffPtr=nullptr)
   {
     MPlexQF msRad;
 #pragma omp simd
@@ -55,7 +56,7 @@ public:
     }
 
     propagateHelixToRMPlex(Err[iC], Par[iC], Chg, msRad,
-                           Err[iP], Par[iP], N_proc, pf);
+                           Err[iP], Par[iP], N_proc, pf, noMatEffPtr);
   }
 
   //----------------------------------------------------------------------------
@@ -73,7 +74,8 @@ public:
                            Err[iP], Par[iP], N_proc, pf);
   }
 
-  void PropagateTracksToHitZ(const MPlexHV& par, const int N_proc, const PropagationFlags pf)
+  void PropagateTracksToHitZ(const MPlexHV& par, const int N_proc, const PropagationFlags pf,
+                             const MPlexQI *noMatEffPtr=nullptr)
   {
     MPlexQF msZ;
 #pragma omp simd
@@ -83,7 +85,7 @@ public:
     }
 
     propagateHelixToZMPlex(Err[iC], Par[iC], Chg, msZ,
-                           Err[iP], Par[iP], N_proc, pf);
+                           Err[iP], Par[iP], N_proc, pf, noMatEffPtr);
   }
 
   void PropagateTracksToPCAZ(const int N_proc, const PropagationFlags pf)

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -303,14 +303,14 @@ int MkBuilder::filter_comb_cands(std::function<filter_track_cand_foo> filter)
   return n_removed;
 }
 
-void MkBuilder::select_best_comb_cands(bool clear_m_tracks)
+void MkBuilder::select_best_comb_cands(bool clear_m_tracks, bool remove_missing_hits)
 {
   if (clear_m_tracks)
     m_tracks.clear();
-  export_best_comb_cands(m_tracks);
+  export_best_comb_cands(m_tracks, remove_missing_hits);
 }
 
-void MkBuilder::export_best_comb_cands(TrackVec &out_vec)
+void MkBuilder::export_best_comb_cands(TrackVec &out_vec, bool remove_missing_hits)
 {
   const EventOfCombCandidates &eoccs = m_event_of_comb_cands;
   out_vec.reserve(out_vec.size() + eoccs.m_size);
@@ -323,7 +323,7 @@ void MkBuilder::export_best_comb_cands(TrackVec &out_vec)
     if ( ! eoccs[i].empty())
     {
       const TrackCand &bcand = eoccs[i].front();
-      out_vec.emplace_back( bcand.exportTrack() );
+      out_vec.emplace_back( bcand.exportTrack(remove_missing_hits) );
     }
   }
 }
@@ -1961,7 +1961,10 @@ void MkBuilder::find_tracks_in_layers(CandCloner &cloner, MkFinder *mkfndr,
       // }
 
       // copy_out the propagated track params, errors only.
-      mkfndr->CopyOutParErr(eoccs.m_candidates, end - itrack, true);
+      // Do not, keep cands at last valid hit until actual update,
+      // this requires change to propagation flags used in MkFinder::UpdateWithLastHit()
+      // from intra-layer to inter-layer.
+      // mkfndr->CopyOutParErr(eoccs.m_candidates, end - itrack, true);
 
       dprint("make new candidates");
       cloner.begin_iteration();

--- a/mkFit/MkBuilder.h
+++ b/mkFit/MkBuilder.h
@@ -160,8 +160,8 @@ public:
 
   // XXX filter for rearranging cands that will / will not do backward search.
 
-  void select_best_comb_cands(bool clear_m_tracks=false);
-  void export_best_comb_cands(TrackVec &out_vec);
+  void select_best_comb_cands(bool clear_m_tracks=false, bool remove_missing_hits=false);
+  void export_best_comb_cands(TrackVec &out_vec, bool remove_missing_hits=false);
   void export_tracks(TrackVec &out_vec);
 
   void CompactifyHitStorageForBestCand(bool remove_seed_hits, int backward_fit_min_hits)

--- a/mkFit/PropagationMPlex.h
+++ b/mkFit/PropagationMPlex.h
@@ -30,7 +30,8 @@ void propagateLineToRMPlex(const MPlexLS &psErr,  const MPlexLV& psPar,
 void propagateHelixToRMPlex(const MPlexLS &inErr,  const MPlexLV& inPar,
                             const MPlexQI &inChg,  const MPlexQF& msRad,
                                   MPlexLS &outErr,       MPlexLV& outPar,
-                            const int      N_proc, const PropagationFlags pflags);
+                            const int      N_proc, const PropagationFlags pflags,
+                            const MPlexQI *noMatEffPtr=nullptr);
 
 void helixAtRFromIterativeCCSFullJac(const MPlexLV& inPar, const MPlexQI& inChg, const MPlexQF &msRad,
                                            MPlexLV& outPar,      MPlexLL& errorProp,
@@ -44,7 +45,8 @@ void helixAtRFromIterativeCCS(const MPlexLV& inPar,  const MPlexQI& inChg, const
 void propagateHelixToZMPlex(const MPlexLS &inErr,  const MPlexLV& inPar,
                             const MPlexQI &inChg,  const MPlexQF& msZ,
                                   MPlexLS &outErr,       MPlexLV& outPar,
-                            const int      N_proc, const PropagationFlags pflags);
+                            const int      N_proc, const PropagationFlags pflags,
+                            const MPlexQI *noMatEffPtr=nullptr);
 
 void helixAtZ(const MPlexLV& inPar,  const MPlexQI& inChg, const MPlexQF &msZ,
                     MPlexLV& outPar,       MPlexLL& errorProp,

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -709,7 +709,7 @@ void run_OneIteration(const TrackerInfo& trackerInfo, const IterationConfig &itc
     }
   }
 
-  builder.export_best_comb_cands(out_tracks);
+  builder.export_best_comb_cands(out_tracks, true);
 
   if (do_remove_duplicates)
   {


### PR DESCRIPTION
- For clone-engine keep candidate state at last valid hit.
- Add option to export candidates without missing hit information, use it for CMSSW runOneIteration().
- In backward fit avoid re-application of material effects when a track does not have a valid hit on current layer.

MTV with PR-372 as ref: http://xrd-cache-1.t2.ucsd.edu/matevz/PKF/no_missing_hits_und_no_mateff_bkfit.vs.PR-372
MTV with CKF as ref: http://xrd-cache-1.t2.ucsd.edu/matevz/PKF/no_missing_hits_und_no_mateff_bkfit.vs.CKF