### PR TITLE
Update duplicate cleaning for pixel-seeded iterations

### DIFF
--- a/Config.cc
+++ b/Config.cc
@@ -87,12 +87,12 @@ namespace Config
   const float maxdPt  = 0.5;
   const float maxdPhi = 0.25;
   const float maxdEta = 0.05;
-  const float maxdR = 0.0025;
+  const float maxdR   = 0.0025;
   const float minFracHitsShared = 0.75;
 
-  const float maxd1pt  = 0.9; //windows for hit
-  const float maxdphi = 0.37; //and/or dr
-  const float maxdcth = 0.37;   //comparisons
+  const float maxd1pt   = 1.8;  //windows for hit
+  const float maxdphi   = 0.37; //and/or dr
+  const float maxdcth   = 0.37; //comparisons
   const float maxcth_ob = 1.99; //eta 1.44
   const float maxcth_fw = 6.05; //eta 2.5
 

--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -681,7 +681,7 @@ namespace
 
     SetupIterationParams(ii[0].m_params, 0);
     ii[0].set_dupclean_flag();
-    ii[0].set_dupl_params(0.5, 0.002,0.004,0.008);
+    ii[0].set_dupl_params(0.24, 0.002,0.004,0.008);
     fill_hit_selection_windows_params(ii[0]);
     // Backward-search with seed region rebuilding
     // SetupBackwardSearch_Iter0(ii[0]);
@@ -692,7 +692,7 @@ namespace
     ii[1].set_iteration_index_and_track_algorithm(1, (int) TrackBase::TrackAlgorithm::highPtTripletStep);
     ii[1].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.018, 0.018, 0.018, 0.05, 0.018, 0.05); 
     ii[1].set_dupclean_flag();
-    ii[1].set_dupl_params(0.5, 0.03,0.05,0.08);
+    ii[1].set_dupl_params(0.24, 0.03,0.05,0.08);
     fill_hit_selection_windows_params(ii[1]);
     ii[1].m_backward_params = ii[1].m_params;
 
@@ -719,7 +719,7 @@ namespace
     ii[4].set_iteration_index_and_track_algorithm(4, (int) TrackBase::TrackAlgorithm::detachedQuadStep);
     ii[4].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
     ii[4].set_dupclean_flag();
-    ii[4].set_dupl_params(0.25, 0.018,0.05,0.05);
+    ii[4].set_dupl_params(0.24, 0.018,0.05,0.05);
     fill_hit_selection_windows_params(ii[4]);
     ii[4].m_backward_params = ii[4].m_params;
     
@@ -728,7 +728,7 @@ namespace
     ii[5].set_iteration_index_and_track_algorithm(5, (int) TrackBase::TrackAlgorithm::detachedTripletStep);
     ii[5].set_seed_cleaning_params(2.0, 0.018, 0.018, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05);
     ii[5].set_dupclean_flag();
-    ii[5].set_dupl_params(0.59, 0.01,0.01,0.1);
+    ii[5].set_dupl_params(0.24, 0.01,0.01,0.1);
     ii[5].m_requires_quality_filter = true;
     fill_hit_selection_windows_params(ii[5]);
     // Backward-search with seed region rebuilding

--- a/mkFit/MkStdSeqs.cc
+++ b/mkFit/MkStdSeqs.cc
@@ -323,8 +323,6 @@ int clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg,
 
     if (writetrack[ts])
     {
-      //if (n_ovlp_hits_added > 0)
-        //seeds[ts].sortHitsByLayer();
       cleanSeedTracks.emplace_back(seeds[ts]);
     }
   }

--- a/mkFit/MkStdSeqs.h
+++ b/mkFit/MkStdSeqs.h
@@ -8,7 +8,6 @@ namespace mkfit {
 
 class Event;
 class EventOfHits;
-
 class IterationConfig;
 
 namespace StdSeq

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -563,7 +563,7 @@ std::vector<double> runBtpCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuil
 	if (itconf.m_track_algorithm==7)
 	{
 	  builder.filter_comb_cands([&](const TrackCand &t)
-	   { return StdSeq::qfilter_n_layers(t, eoh.m_beam_spot); });      
+	   { return StdSeq::qfilter_n_layers(t, eoh.m_beam_spot, Config::TrkInfo); });      
 	}
 	else if (itconf.m_track_algorithm==9)
 	{
@@ -702,7 +702,7 @@ void run_OneIteration(const TrackerInfo& trackerInfo, const IterationConfig &itc
       if (itconf.m_track_algorithm==7)
       {
 	builder.filter_comb_cands([&](const TrackCand &t)
-	 { return StdSeq::qfilter_n_layers(t, eoh.m_beam_spot); });      
+	 { return StdSeq::qfilter_n_layers(t, eoh.m_beam_spot, trackerInfo); });      
       }
       else if (itconf.m_track_algorithm==9)
       {


### PR DESCRIPTION
### PR description:
Update of duplicate cleaning for pixel-seeded iterations:
(1) reduce min fraction of shared hits;
(2) loosen max d(1/pT) for duplicate cleaning based on shared hits.
This is meant to address the large fake rate observed in high-pT QCD samples.

In addition, the quality filter for detachedTripletStep is tightened, in order to suppress fakes further (mostly visible in TTbar).

### PR validation:
- QCD (high-pT,  no-PU): http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/PRvalidation_Oct27/MTV_QCD_pr377/

--> In pixel-seeded iterations, we retain efficiency >= CKF, while reducing fakes to similar level as CKF.

- TTbar (with PU): http://uaf-10.t2.ucsd.edu/~mmasciov/MkFit_devs/PRvalidation_Oct27/MTV_TTbar_pr377/

--> Negligible difference is found in pixel-seeded iterations for TTbar, which shall anyways be input to DNN retraining.

Additional MTV results can be found in a dedicated [gdoc](https://docs.google.com/document/d/1-3AKnmquMF13xcA0CAB2Rn0KaaqI2bJlyo3L4Qc4dR8/edit?usp=sharing). 