### PR TITLE
Tighten pixelLessStep filter

### DIFF
--- a/mkFit/MkStdSeqs.h
+++ b/mkFit/MkStdSeqs.h
@@ -131,9 +131,14 @@ namespace StdSeq
       float invptmin  = 1.11; // =1/0.9
 
       float thetasym = std::abs(t.theta() - Config::PIOver2);
-      float thetasymmin = 0.8; // -> |eta|=0.9
+      float thetasymmin_l = 0.80; // -> |eta|=0.9
+      float thetasymmin_h = 1.11; // -> |eta|=1.45
 
-      return !( (nLyrs<=3 || nHits<=3) || ( (nLyrs<=4 || nHits<=4) && (invpt<invptmin || (thetasym>thetasymmin && std::abs(d0BS)>d0_max)) ) );
+      return !(
+	       ( ( nLyrs<=3 || nHits<=3 ) ) ||
+	       ( ( nLyrs<=4 || nHits<=4 ) && ( invpt<invptmin || (thetasym>thetasymmin_l && std::abs(d0BS)>d0_max) ) ) ||
+	       ( ( nLyrs<=6 || nHits<=6 ) && ( invpt>invptmin &&  thetasym>thetasymmin_h && std::abs(d0BS)>d0_max  ) )
+	       );
     }
 
     template<class TRACK>


### PR DESCRIPTION
### PR description:

As per title, after PR #381: tightening of pixelLessStep filter in endcaps & at low pT.


### PR validation:

- TTbar with PU: https://mmasciovecchio.web.cern.ch/MkFit_hitSelectionWindows_Nov21/MTV_TTbar_PU_PR382_12X/plots_pixelLessStep.html

- High-pT QCD without PU: https://mmasciovecchio.web.cern.ch/MkFit_hitSelectionWindows_Nov21/MTV_highPtQCD_noPU_PR382_12X/plots_pixelLessStep.html

--> Mild loss of efficiency in endcaps & at low pT, with significant reduction of fakes.

As a result, OOB high-purity tracks are back under control:

- TTbar with PU: https://mmasciovecchio.web.cern.ch/MkFit_hitSelectionWindows_Nov21/MTV_TTbar_PU_PR382_12X/plots_highPurity/effandfakePtEtaPhi.pdf

- High-pT QDC without PU: https://mmasciovecchio.web.cern.ch/MkFit_hitSelectionWindows_Nov21/MTV_highPtQCD_noPU_PR382_12X/plots_highPurity/effandfakePtEtaPhi.pdf
