### PR TITLE
Builder release memory per event

### DIFF
--- a/mkFit/CandCloner.cc
+++ b/mkFit/CandCloner.cc
@@ -114,7 +114,7 @@ void CandCloner::ProcessSeedRange(int is_beg, int is_end)
         // set the overlap if we have a true hit and pT > pTCutOverlap
         HitMatch *hm;
         if (tc.pT() > mp_iteration_params->pTCutOverlap && h2a.hitIdx >= 0 &&
-            (hm = ccand.findOverlap(h2a.trkIdx, h2a.hitIdx, h2a.module)))
+            (hm = ccand[h2a.trkIdx].findOverlap(h2a.hitIdx, h2a.module)))
         {
           tc.addHitIdx(hm->m_hit_idx, m_layer, hm->m_chi2);
           tc.incOverlapCount();

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -910,9 +910,13 @@ public:
 
   void ReleaseMemory()
   {
-    m_cc_pool.release();
+    { // Get all the destructors called before nuking CcPool.
+      std::vector<CombCandidate> tmp;
+      m_candidates.swap(tmp);
+    }
     m_capacity = 0;
     m_size = 0;
+    m_cc_pool.release();
   }
 
   void Reset(int new_capacity, int max_cands_per_seed, int expected_num_hots = 128)

--- a/mkFit/HitStructures.h
+++ b/mkFit/HitStructures.h
@@ -333,9 +333,9 @@ struct HoTNode
 
 struct HitMatch
 {
-  int   m_hit_idx;
-  int   m_module_id;
-  float m_chi2;
+  int   m_hit_idx   = -1;
+  int   m_module_id = -1;
+  float m_chi2      = 1e9;
 
   void reset() { m_hit_idx = -1;  m_module_id = -1; m_chi2 = 1e9; }
 };
@@ -410,6 +410,14 @@ public:
     m_size = size;
 
     // printf("CcP reset to %zu\n", size);
+  }
+
+  void release()
+  {
+    std::vector<T> tmp;
+    m_mem.swap(tmp);
+    m_pos = 0;
+    m_size = 0;
   }
 
   CcPool(std::size_t size=0)
@@ -501,6 +509,16 @@ public:
   int  originIndex()    const { return m_origin_index; }
   void setOriginIndex(int oi) { m_origin_index = oi; }
 
+  void resetOverlaps() { m_overlap_hits.reset(); }
+  void considerHitForOverlap(int hit_idx, int module_id, float chi2)
+  {
+    m_overlap_hits.consider_hit_for_overlap(hit_idx, module_id, chi2);
+  }
+  HitMatch* findOverlap(int hit_idx, int module_id)
+  {
+    return m_overlap_hits.find_overlap(hit_idx, module_id);
+  }
+
   // Inlines after definition of CombCandidate
 
   HitOnTrack getLastHitOnTrack() const;
@@ -534,6 +552,7 @@ public:
 
 protected:
   CombCandidate *m_comb_candidate = nullptr;
+  HitMatchPair   m_overlap_hits;
 
   // using from TrackBase:
   // short int lastHitIdx_
@@ -589,8 +608,6 @@ public:
   int                  m_hots_size = 0;
   std::vector<HoTNode> m_hots;
 
-  std::vector<HitMatchPair> m_overlap_hits; // XXXX HitMatchPair could be a member in TrackCand
-
 
   CombCandidate(const allocator_type& alloc) :
     std::vector<TrackCand, CcAlloc<TrackCand>>(alloc),
@@ -610,8 +627,7 @@ public:
     m_seed_label(o.m_seed_label),
 #endif
     m_hots_size(o.m_hots_size),
-    m_hots(o.m_hots),
-    m_overlap_hits(o.m_overlap_hits)
+    m_hots(o.m_hots)
   {}
 
   // Required for std::swap().
@@ -628,8 +644,7 @@ public:
     m_seed_label(o.m_seed_label),
 #endif
     m_hots_size(o.m_hots_size),
-    m_hots(std::move(o.m_hots)),
-    m_overlap_hits(std::move(o.m_overlap_hits))
+    m_hots(std::move(o.m_hots))
   {
     // This is not needed as we do EOCC::Reset() after EOCCS::resize which
     // calls Reset here and all CombCands get cleared.
@@ -657,7 +672,6 @@ public:
 #endif
     m_hots_size = o.m_hots_size;
     m_hots = std::move(o.m_hots);
-    m_overlap_hits = std::move(o.m_overlap_hits);
 
     for (auto &tc : *this) tc.setCombCandidate(this);
 
@@ -681,8 +695,6 @@ public:
     m_hots.reserve(expected_num_hots);
     m_hots_size = 0;
     m_hots.clear();
-
-    m_overlap_hits.resize(max_cands_per_seed);
   }
 
   void ImportSeed(const Track& seed, int region);
@@ -691,16 +703,6 @@ public:
   {
     m_hots.push_back({hot, chi2, prev_idx});
     return m_hots_size++;
-  }
-
-  void considerHitForOverlap(int cand_idx, int hit_idx, int module_id, float chi2)
-  {
-    m_overlap_hits[cand_idx].consider_hit_for_overlap(hit_idx, module_id, chi2);
-  }
-
-  HitMatch* findOverlap(int cand_idx, int hit_idx, int module_id)
-  {
-    return m_overlap_hits[cand_idx].find_overlap(hit_idx, module_id);
   }
 
   void MergeCandsAndBestShortOne(const IterationParams&params, bool update_score, bool sort_cands);
@@ -905,6 +907,13 @@ public:
     m_capacity  (0),
     m_size      (0)
   {}
+
+  void ReleaseMemory()
+  {
+    m_cc_pool.release();
+    m_capacity = 0;
+    m_size = 0;
+  }
 
   void Reset(int new_capacity, int max_cands_per_seed, int expected_num_hots = 128)
   {

--- a/mkFit/MkBuilder.cc
+++ b/mkFit/MkBuilder.cc
@@ -204,6 +204,13 @@ void MkBuilder::end_event()
   m_event = nullptr;
 }
 
+void MkBuilder::release_memory()
+{
+  TrackVec tmp;
+  m_tracks.swap(tmp);
+  m_event_of_comb_cands.ReleaseMemory();
+}
+
 void MkBuilder::import_seeds(const TrackVec &in_seeds, std::function<insert_seed_foo> insert_seed)
 {
   // bool debug = true;
@@ -1504,7 +1511,7 @@ int MkBuilder::find_tracks_unroll_candidates(std::vector<std::pair<int,int>> & s
 
           active = true;
           seed_cand_vec.push_back(std::pair<int,int>(iseed,ic));
-          ccand.m_overlap_hits[ic].reset();
+          ccand[ic].resetOverlaps();
 
           if (Config::nan_n_silly_check_cands_every_layer)
           {
@@ -1747,7 +1754,7 @@ void MkBuilder::FindTracksStandard(SteeringParams::IterationType_e iteration_dir
               {
                 CombCandidate &ccand = eoccs[start_seed + is];
 
-                HitMatch *hm = ccand.findOverlap(tc.originIndex(), tc.getLastHitIdx(), layer_of_hits.GetHit(tc.getLastHitIdx()).detIDinLayer());
+                HitMatch *hm = ccand[tc.originIndex()].findOverlap(tc.getLastHitIdx(), layer_of_hits.GetHit(tc.getLastHitIdx()).detIDinLayer());
 
                 if (hm)
                 {

--- a/mkFit/MkBuilder.h
+++ b/mkFit/MkBuilder.h
@@ -154,6 +154,8 @@ public:
 
   void begin_event(MkJob *job, Event *ev, const char *build_type);
   void end_event();
+  void release_memory();
+
   void import_seeds(const TrackVec &in_seeds, std::function<insert_seed_foo> insert_seed);
 
   int  filter_comb_cands(std::function<filter_track_cand_foo> filter);

--- a/mkFit/MkBuilder.h
+++ b/mkFit/MkBuilder.h
@@ -158,9 +158,10 @@ public:
 
   void import_seeds(const TrackVec &in_seeds, std::function<insert_seed_foo> insert_seed);
 
+  // filter for rearranging cands that will / will not do backward search.
   int  filter_comb_cands(std::function<filter_track_cand_foo> filter);
 
-  // XXX filter for rearranging cands that will / will not do backward search.
+  void find_min_max_hots_size();
 
   void select_best_comb_cands(bool clear_m_tracks=false, bool remove_missing_hits=false);
   void export_best_comb_cands(TrackVec &out_vec, bool remove_missing_hits=false);

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -1021,7 +1021,7 @@ void MkFinder::FindCandidates(const LayerOfHits                   &layer_of_hits
               if (chi2 < m_iteration_params->chi2CutOverlap)
               {
                 CombCandidate &ccand = * newcand.combCandidate();
-                ccand.considerHitForOverlap(CandIdx(itrack, 0, 0), hit_idx, layer_of_hits.GetHit(hit_idx).detIDinLayer(), chi2);
+                ccand[CandIdx(itrack, 0, 0)].considerHitForOverlap(hit_idx, layer_of_hits.GetHit(hit_idx).detIDinLayer(), chi2);
               }
 
               dprint("updated track parameters x=" << newcand.parameters()[0] << " y=" << newcand.parameters()[1] << " z=" << newcand.parameters()[2] << " pt=" << 1./newcand.parameters()[3]);
@@ -1164,7 +1164,7 @@ void MkFinder::FindCandidatesCloneEngine(const LayerOfHits &layer_of_hits, CandC
             if (chi2 < m_iteration_params->chi2CutOverlap)
             {
               CombCandidate &ccand = cloner.mp_event_of_comb_candidates->m_candidates[ SeedIdx(itrack, 0, 0) ];
-              ccand.considerHitForOverlap(CandIdx(itrack, 0, 0), hit_idx, layer_of_hits.GetHit(hit_idx).detIDinLayer(), chi2);
+              ccand[CandIdx(itrack, 0, 0)].considerHitForOverlap(hit_idx, layer_of_hits.GetHit(hit_idx).detIDinLayer(), chi2);
             }
 
             IdxChi2List tmpList;

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -505,6 +505,9 @@ std::vector<double> runBtpCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuil
     timevec[it] = dtime() - time;
     timevec[n] += timevec[it];
 
+    // Print min and max size of hots vectors of CombCands.
+    // builder.find_min_max_hots_size();
+
     if (validation_on)  seeds_used.insert(seeds_used.end(), seeds.begin(), seeds.end());//cleaned seeds need to be stored somehow
 
     if (itconf.m_requires_quality_filter && itconf.m_track_algorithm!=7)
@@ -617,7 +620,7 @@ std::vector<double> runBtpCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuil
   builder.end_event(); 
 
   // In CMSSW runOneIter we now release memory for comb-cands:
-  // builder.release_memory();
+  builder.release_memory();
 
   return timevec;
 }

--- a/mkFit/buildtestMPlex.cc
+++ b/mkFit/buildtestMPlex.cc
@@ -616,6 +616,9 @@ std::vector<double> runBtpCe_MultiIter(Event& ev, const EventOfHits &eoh, MkBuil
   // MIMI Unfake.
   builder.end_event(); 
 
+  // In CMSSW runOneIter we now release memory for comb-cands:
+  // builder.release_memory();
+
   return timevec;
 }
 
@@ -733,6 +736,7 @@ void run_OneIteration(const TrackerInfo& trackerInfo, const IterationConfig &itc
   }
 
   builder.end_event();
+  builder.release_memory();
 }
 
 } // end namespace mkfit


### PR DESCRIPTION
Memory allocated for TrackCand vectors is released on every event / iteration -- before it was growing to accommodate the largest event seen so far.

Further, overlap hit-storage vector that was member of CombinedCandidate has been moved as member variable in TrackCand -- thus it does not need to be allocated as a vector per seed anymore.

igProf MEM_LIVE 50 ttbar pu 50 events:
http://xrd-cache-1.t2.ucsd.edu/matevz/igProf/igprof-navigator.py/IgProf.50

DQM file for 7 iterations, ttbar 50 isin phi3:/data2/matevz/CMSSW_11_2_0/src/mem_test/ ... I don't have relevant reference files on hand.
