### PR TITLE
Increase window SF and chi2Cut_min to recover hits

### DIFF
--- a/Geoms/CMS-2017.cc
+++ b/Geoms/CMS-2017.cc
@@ -145,7 +145,7 @@ namespace
       ip.maxCandsPerSeed  = 5;
       ip.maxHolesPerCand  = 4;
       ip.maxConsecHoles   = 2;
-      ip.chi2Cut_min      = 10.0;
+      ip.chi2Cut_min      = 15.0;
       ip.chi2CutOverlap   = 3.5;
       ip.pTCutOverlap     = 1;
     }
@@ -155,7 +155,7 @@ namespace
       ip.maxCandsPerSeed  = 5;
       ip.maxHolesPerCand  = 4;
       ip.maxConsecHoles   = 2;
-      ip.chi2Cut_min      = 10.0; 
+      ip.chi2Cut_min      = 15.0;
       ip.chi2CutOverlap   = 3.5;
       ip.pTCutOverlap     = 1;
     }
@@ -165,7 +165,7 @@ namespace
       ip.maxCandsPerSeed  = 5;
       ip.maxHolesPerCand  = 4;
       ip.maxConsecHoles   = 2;
-      ip.chi2Cut_min      = 10.0; 
+      ip.chi2Cut_min      = 15.0;
       ip.chi2CutOverlap   = 3.5;
       ip.pTCutOverlap     = 1;
     } 
@@ -175,7 +175,7 @@ namespace
       ip.maxCandsPerSeed  = 5;
       ip.maxHolesPerCand  = 4;
       ip.maxConsecHoles   = 2;
-      ip.chi2Cut_min      = 10.0; 
+      ip.chi2Cut_min      = 15.0;
       ip.chi2CutOverlap   = 3.5;
       ip.pTCutOverlap     = 1;
     } 
@@ -185,7 +185,7 @@ namespace
       ip.maxCandsPerSeed  = 5;
       ip.maxHolesPerCand  = 4;
       ip.maxConsecHoles   = 2;
-      ip.chi2Cut_min      = 10.0; 
+      ip.chi2Cut_min      = 15.0;
       ip.chi2CutOverlap   = 3.5;
       ip.pTCutOverlap     = 1;
     } 
@@ -195,7 +195,7 @@ namespace
       ip.maxCandsPerSeed  = 5;
       ip.maxHolesPerCand  = 4;
       ip.maxConsecHoles   = 2;
-      ip.chi2Cut_min      = 10.0; 
+      ip.chi2Cut_min      = 15.0;
       ip.chi2CutOverlap   = 3.5;
       ip.pTCutOverlap     = 1;
     } 
@@ -205,7 +205,7 @@ namespace
       ip.maxCandsPerSeed  = 2;
       ip.maxHolesPerCand  = 4;
       ip.maxConsecHoles   = 2;
-      ip.chi2Cut_min      = 10.0;
+      ip.chi2Cut_min      = 15.0;
       ip.chi2CutOverlap   = 3.5;
       ip.pTCutOverlap     = 1;
     } 
@@ -215,7 +215,7 @@ namespace
       ip.maxCandsPerSeed  = 2;
       ip.maxHolesPerCand  = 0;
       ip.maxConsecHoles   = 1;
-      ip.chi2Cut_min      = 10.0; 
+      ip.chi2Cut_min      = 15.0;
       ip.chi2CutOverlap   = 3.5;
       ip.pTCutOverlap     = 1;
     }   
@@ -225,7 +225,7 @@ namespace
       ip.maxCandsPerSeed  = 2;
       ip.maxHolesPerCand  = 0;
       ip.maxConsecHoles   = 1;
-      ip.chi2Cut_min      = 10.0; 
+      ip.chi2Cut_min      = 15.0;
       ip.chi2CutOverlap   = 3.5;
       ip.pTCutOverlap     = 1;
     }
@@ -235,7 +235,7 @@ namespace
       ip.maxCandsPerSeed  = 3;
       ip.maxHolesPerCand  = 4;
       ip.maxConsecHoles   = 2;
-      ip.chi2Cut_min      = 10.0;
+      ip.chi2Cut_min      = 15.0;
       ip.chi2CutOverlap   = 3.5;
       ip.pTCutOverlap     = 1;
     }

--- a/mkFit/IterationConfig.h
+++ b/mkFit/IterationConfig.h
@@ -65,17 +65,17 @@ public:
 
   //Hit selection windows: 2D fit/layer (72 in phase-1 CMS geometry)
   //cut = [0]*1/pT + [1]*std::fabs(theta-pi/2) + [2])
-  float c_dp_sf = 1.05;
+  float c_dp_sf = 1.1;
   float c_dp_0  = 0.0;
   float c_dp_1  = 0.0;
   float c_dp_2  = 0.0;
   //
-  float c_dq_sf = 1.05;
+  float c_dq_sf = 1.1;
   float c_dq_0  = 0.0;
   float c_dq_1  = 0.0;
   float c_dq_2  = 0.0;
   //
-  float c_c2_sf = 1.05;
+  float c_c2_sf = 1.1;
   float c_c2_0  = 0.0;
   float c_c2_1  = 0.0;
   float c_c2_2  = 0.0;
@@ -98,7 +98,7 @@ public:
   int   maxCandsPerSeed   = 5;
   int   maxHolesPerCand   = 4;
   int   maxConsecHoles    = 1;
-  float chi2Cut_min       = 10.0;
+  float chi2Cut_min       = 15.0;
   float chi2CutOverlap    = 3.5;
   float pTCutOverlap      = 1.0;
   // NOTE: iteration params could actually become layer-dependent, e.g., chi2Cut could be larger for first layers (?)

--- a/mkFit/MkFinder.cc
+++ b/mkFit/MkFinder.cc
@@ -173,7 +173,7 @@ void MkFinder::getHitSelDynamicWindows(const float invpt, const float theta, flo
   // dq hit selection window
   float this_dq = (ILC.c_dq_0)*max_invpt+(ILC.c_dq_1)*theta+(ILC.c_dq_2);  
   // In case layer is missing (e.g., seeding layers, or too low stats for training), leave original limits
-  if(this_dq>0.f){
+  if((ILC.c_dq_sf)*this_dq>0.f){
     min_dq = (ILC.c_dq_sf)*this_dq;
     max_dq = 2.0f*min_dq;
   }
@@ -213,7 +213,7 @@ inline float MkFinder::getHitSelDynamicChi2Cut(const int itrk, const int ipar)
 
   float this_c2 = ILC.c_c2_0*max_invpt + ILC.c_c2_1*theta + ILC.c_c2_2;
   // In case layer is missing (e.g., seeding layers, or too low stats for training), leave original limits
-  if (this_c2 > minChi2Cut)
+  if ((ILC.c_c2_sf)*this_c2 > minChi2Cut)
     return ILC.c_c2_sf*this_c2;
   else
     return minChi2Cut;


### PR DESCRIPTION
### PR description:

This PR acts on top of PR #385 and increases the flat SF applied to hit selection windows, in order to recover hits. With the same goal, the min chi2 cut is explicitly increased to 15.0.

### PR validation:
- TTbar with <PU>=50: https://mmasciovecchio.web.cern.ch/MkFit_hitSelectionWindows_Nov21/MTV_fixHitSelWindows_minChi215p0_SF1p1_Nov21_TTbarPU50_122X/
- 10muPt0p2to10: https://mmasciovecchio.web.cern.ch/MkFit_hitSelectionWindows_Nov21/MTV_fixHitSelWindows_minChi215p0_SF1p1_Nov21_10muPt0p2to10_122X/

--> A slight increase in fakes is found, in exchange for an increase in number of hits (and a slight improvement in resolutions, especially pT resolution).